### PR TITLE
:construction_worker: setup snapshot releases

### DIFF
--- a/.changeset/late-forks-crash.md
+++ b/.changeset/late-forks-crash.md
@@ -1,5 +1,0 @@
----
-"@postenbring/hedwig-tokens": patch
----
-
-testing out snapshots on github actions


### PR DESCRIPTION
From now on, any push on a branch that includes a changeset will publish a snapshot release of the affected packages 🙌 
Ref. https://github.com/changesets/changesets/blob/main/docs/snapshot-releases.md

It works 🎉
https://www.npmjs.com/package/@postenbring/hedwig-tokens/v/0.0.0-setup-snapshot-releases-20231111164438
<img width="825" alt="image" src="https://github.com/bring/hedwig-design-system/assets/244257/959c676a-a67c-47ca-b0a3-005211da0fd7">
