### PR TITLE
rename types and fix autodocs

### DIFF
--- a/packages/react/src/badge/badge.tsx
+++ b/packages/react/src/badge/badge.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { clsx } from "clsx";
 import { t } from "@postenbring/hedwig-css/typed-classname/index.mjs";
-import { warnForStyleOverridesAndRender } from "../utils";
+import { warnForStyleOverrides } from "../utils";
 
 export interface BadgeProps
   extends Omit<React.AnchorHTMLAttributes<HTMLSpanElement>, "className" | "style"> {
@@ -19,11 +19,11 @@ function BaseBadge({
   size = "small",
   ...rest
 }: BadgeProps & { variant: "primary" | "dark" | "white" | "warning" }) {
-  return warnForStyleOverridesAndRender(
-    rest,
+  warnForStyleOverrides(rest);
+  return (
     <span className={clsx(t("hds-badge"), t(`hds-badge--${size}`), t(`hds-badge--${variant}`))}>
       {children}
-    </span>,
+    </span>
   );
 }
 

--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -2,7 +2,7 @@
 import * as React from "react";
 import { clsx } from "clsx";
 import { t } from "@postenbring/hedwig-css/typed-classname/index.mjs";
-import { warnForStyleOverridesAndRender } from "../utils";
+import { warnForStyleOverrides } from "../utils";
 
 export interface ButtonProps
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "className" | "style"> {
@@ -35,8 +35,8 @@ function BaseButton({
   buttonRef,
   ...rest
 }: ButtonProps & { variant: "primary" | "secondary" }) {
-  return warnForStyleOverridesAndRender(
-    rest,
+  warnForStyleOverrides(rest);
+  return (
     <button
       className={clsx(t("hds-button"), t(`hds-button--${size}`), {
         [t(`hds-button--${variant}`)]: fill === "contained",
@@ -48,7 +48,7 @@ function BaseButton({
       {...rest}
     >
       {children}
-    </button>,
+    </button>
   );
 }
 

--- a/packages/react/src/link/link.tsx
+++ b/packages/react/src/link/link.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { clsx } from "clsx";
 import { t } from "@postenbring/hedwig-css/typed-classname/index.mjs";
-import { warnForStyleOverridesAndRender } from "../utils";
+import { warnForStyleOverrides } from "../utils";
 
 export interface LinkProps
   extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "className" | "style"> {
@@ -31,8 +31,8 @@ export function Link({
   anchorRef,
   ...rest
 }: LinkProps) {
-  return warnForStyleOverridesAndRender(
-    rest,
+  warnForStyleOverrides(rest);
+  return (
     <a
       className={clsx(
         t("hds-link"),
@@ -43,7 +43,7 @@ export function Link({
       {...rest}
     >
       {children}
-    </a>,
+    </a>
   );
 }
 

--- a/packages/react/src/list/description-list.stories.tsx
+++ b/packages/react/src/list/description-list.stories.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies -- storybook story */
 import type { Meta, StoryObj } from "@storybook/react";
-import type { DLProps } from "./description-list";
+import type { DescriptionListProps } from "./description-list";
 import { DescriptionDetails, DescriptionList, DescriptionTerm } from ".";
 
 type Story = StoryObj<typeof DescriptionList>;
-type DLVariant = Pick<DLProps, "variant">;
+type DLVariant = Pick<DescriptionListProps, "variant">;
 
 const DLStory = (variant: DLVariant): Story => ({
   args: {
@@ -31,15 +31,5 @@ export const Default: Story = DLStory({ variant: "vertical" });
 const meta: Meta<typeof DescriptionList> = {
   title: "Description List",
   component: DescriptionList,
-  argTypes: {
-    children: {
-      description: "Either DT or DD elements",
-    },
-    variant: {
-      type: "string",
-      defaultValue: "vertical",
-      description: "Direction of the description list",
-    },
-  },
 };
 export default meta;

--- a/packages/react/src/list/description-list.tsx
+++ b/packages/react/src/list/description-list.tsx
@@ -2,40 +2,46 @@ import type { HTMLAttributes, ReactNode } from "react";
 import React from "react";
 import { clsx } from "clsx";
 import { t } from "@postenbring/hedwig-css/typed-classname/index.mjs";
-import { warnForStyleOverridesAndRender } from "../utils";
+import { warnForStyleOverrides } from "../utils";
 
-type DDProps = DLDTProps;
-type DTProps = DLDTProps;
+export type DescriptionDetailsProps = DLDTProps;
+export type DescriptionTermProps = DLDTProps;
 
-export interface DLDTProps
-  extends Omit<React.HTMLAttributes<HTMLBaseElement>, "className" | "style"> {
+interface DLDTProps extends Omit<React.HTMLAttributes<HTMLBaseElement>, "className" | "style"> {
   children: ReactNode;
 }
 
-export interface DLProps extends Omit<HTMLAttributes<HTMLDListElement>, "className" | "style"> {
+export interface DescriptionListProps
+  extends Omit<HTMLAttributes<HTMLDListElement>, "className" | "style"> {
+  /**
+   * Either `DescriptionDetails` or `DescriptionTerm` elements
+   */
+  children: ReactNode;
   /**
    * Direction of the description list
    */
   variant?: "vertical" | "horizontal";
 }
 
-export function DescriptionDetails({ children, ...rest }: DDProps) {
-  return warnForStyleOverridesAndRender(rest, <dd {...rest}>{children}</dd>);
+export function DescriptionDetails({ children, ...rest }: DescriptionDetailsProps) {
+  warnForStyleOverrides(rest);
+  return <dd {...rest}>{children}</dd>;
 }
 
-export function DescriptionTerm({ children, ...rest }: DTProps) {
-  return warnForStyleOverridesAndRender(rest, <dt {...rest}>{children}</dt>);
+export function DescriptionTerm({ children, ...rest }: DescriptionTermProps) {
+  warnForStyleOverrides(rest);
+  return <dt {...rest}>{children}</dt>;
 }
 
-export function DescriptionList({ variant = "vertical", ...rest }: DLProps) {
-  return warnForStyleOverridesAndRender(
-    rest,
+export function DescriptionList({ variant = "vertical", ...rest }: DescriptionListProps) {
+  warnForStyleOverrides(rest);
+  return (
     <dl
       className={clsx(t("hds-description-list"), {
         [t("hds-description-list--horizontal")]: variant === "horizontal",
       })}
       {...rest}
-    />,
+    />
   );
 }
 

--- a/packages/react/src/list/index.tsx
+++ b/packages/react/src/list/index.tsx
@@ -3,4 +3,4 @@ import "@postenbring/hedwig-css/dist/base.css";
 
 import "@postenbring/hedwig-css/dist/list/description-list.css";
 
-export { DescriptionDetails, DescriptionList, DescriptionTerm } from "./description-list";
+export * from "./description-list";

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,15 +1,5 @@
 /* eslint-disable no-console -- console.warn for unsupported features */
 
-import type { JSX } from "react";
-
-export function warnForStyleOverridesAndRender(
-  props: Record<string, unknown>,
-  component: JSX.Element,
-): JSX.Element {
-  warnForStyleOverrides(props);
-  return component;
-}
-
 export function warnForStyleOverrides(props: Record<string, unknown>) {
   if (props.className) {
     console.warn("Overriding styles are not premited");


### PR DESCRIPTION
autodocs aka react-codegen is a bit picky when generating, it prefers simple components. Which I guess is fine, since so should we.

| Before | After |
|--------|--------|
| ![image](https://github.com/bring/hedwig-design-system/assets/244257/c06e9f33-8e00-4469-aabd-b387b34ccfec) | <img width="858" alt="image" src="https://github.com/bring/hedwig-design-system/assets/244257/dcf159ec-3be8-4450-b5fd-de3682b29ec4"> | 