### PR TITLE
:wrench: simplify tsup config

### DIFF
--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,19 +1,5 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: [
-    "src/index.tsx",
-
-    "src/button/index.tsx",
-    "src/button/button.tsx",
-
-    "src/badge/index.tsx",
-    "src/badge/badge.tsx",
-
-    "src/link/index.tsx",
-    "src/link/link.tsx",
-
-    "src/list/index.tsx",
-    "src/list/description-list.tsx",
-  ],
+  entry: ["src/index.tsx", "src/**/*.tsx", "!src/**/*.stories.tsx"],
 });


### PR DESCRIPTION
use wildcard matching for entrypoints, while excluding the storybook stories


Not documented, but tsup uses [`globby`](https://github.com/sindresorhus/globby) which supports negated patterns. Found it by looking at [tsup's package.json](https://github.com/egoist/tsup/blob/dev/package.json#L38)
<img width="490" alt="image" src="https://github.com/bring/hedwig-design-system/assets/244257/94943341-1ca7-4d57-b0e8-74a85bc5d56b">
