### PR TITLE
:lipstick: style improvements to `Message`

### DIFF
--- a/.changeset/early-readers-hide.md
+++ b/.changeset/early-readers-hide.md
@@ -1,0 +1,6 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+:lipstick: add `Message.Title` and `Message.Description` helper components to `Message` & Fix 2px missing margin for the first text so it matches the icon

--- a/packages/css/src/message/message.css
+++ b/packages/css/src/message/message.css
@@ -59,4 +59,27 @@
       width: var(--hds-component-message-icon-width);
     }
   }
+
+  /* Reset margin */
+  & .hds-message__title,
+  & .hds-message__description {
+    margin: 0;
+  }
+
+  /* Offset to match the icon */
+  & *:is(.hds-message__title, .hds-message__description):first-of-type {
+    margin-top: 2px;
+  }
+
+  & .hds-message__title {
+    font: var(--hds-typography-body-title);
+  }
+
+  & .hds-message__title ~ .hds-message__description {
+    margin-top: var(--hds-spacing-small-3);
+
+    @media (min-width: 720px) {
+      margin-top: var(--hds-spacing-small-4);
+    }
+  }
 }

--- a/packages/react/src/message/index.tsx
+++ b/packages/react/src/message/index.tsx
@@ -5,4 +5,17 @@ import "@postenbring/hedwig-css/dist/base.css";
 import "@postenbring/hedwig-css/dist/box.css";
 import "@postenbring/hedwig-css/dist/message.css";
 
-export * from "./message";
+import { Message, MessageTitle, MessageDescription } from "./message";
+
+const MessageComponent = Message as typeof Message & {
+  Title: typeof MessageTitle;
+  Description: typeof MessageDescription;
+};
+
+MessageComponent.Title = MessageTitle;
+MessageComponent.Description = MessageDescription;
+
+MessageComponent.Title.displayName = "Message";
+MessageComponent.Description.displayName = "Message";
+
+export { MessageComponent as Message, MessageTitle, MessageDescription };

--- a/packages/react/src/message/message.stories.tsx
+++ b/packages/react/src/message/message.stories.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies -- storybook story */
 import type { Meta, StoryObj } from "@storybook/react";
-import { clsx } from "@postenbring/hedwig-css/typed-classname/index.mjs";
 import { useState } from "react";
 import { Message } from ".";
 
@@ -10,13 +9,11 @@ const meta: Meta<typeof Message> = {
   args: {
     children: (
       <>
-        <h3 className={clsx("hds-typography-h3", "hds-typography-h3--title")} style={{ margin: 0 }}>
-          Message header
-        </h3>
-        <p>
+        <Message.Title>Message header</Message.Title>
+        <Message.Description>
           Message header Message description. A more detailed explanation of whats happening, but
           not too long.
-        </p>
+        </Message.Description>
       </>
     ),
   },
@@ -60,10 +57,8 @@ export const Neutral: Story = {
     const [_, rerender] = useState(0);
     return (
       <Message icon={<span style={{ fontSize: 24 }}>{icon}</span>} variant="neutral">
-        <h3 className={clsx("hds-typography-h3", "hds-typography-h3--title")} style={{ margin: 0 }}>
-          Custom icons
-        </h3>
-        <p>
+        <Message.Title>Custom icons</Message.Title>
+        <Message.Description>
           Icon is a prop, so you can use whatever you like.
           <button
             onClick={() => {
@@ -73,8 +68,32 @@ export const Neutral: Story = {
           >
             Rerender
           </button>
-        </p>
+        </Message.Description>
       </Message>
     );
+  },
+};
+
+export const TitleOnly: Story = {
+  args: {
+    variant: "attention",
+    children: <Message.Title>Message header</Message.Title>,
+  },
+};
+
+export const DescriptionOnly: Story = {
+  args: {
+    children: <Message.Description>Message description</Message.Description>,
+  },
+};
+
+export const LongDescriptionOnly: Story = {
+  args: {
+    children: (
+      <Message.Description>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec et dolor id nisl consectetur
+        aliquet. Donec euismod, nibh et aliquam tincidunt, nunc urna ultricies
+      </Message.Description>
+    ),
   },
 };

--- a/packages/react/src/message/message.tsx
+++ b/packages/react/src/message/message.tsx
@@ -36,3 +36,29 @@ export const Message: OverridableComponent<MessageProps, HTMLDivElement> = forwa
   },
 );
 Message.displayName = "Message";
+
+export const MessageTitle: OverridableComponent<object, HTMLParagraphElement> = forwardRef(
+  ({ as: Component = "p", className, ...rest }, ref) => {
+    return (
+      <Component
+        className={clsx("hds-message__title", className as undefined)}
+        ref={ref}
+        {...rest}
+      />
+    );
+  },
+);
+MessageTitle.displayName = "MessageTitle";
+
+export const MessageDescription: OverridableComponent<object, HTMLParagraphElement> = forwardRef(
+  ({ as: Component = "p", className, ...rest }, ref) => {
+    return (
+      <Component
+        className={clsx("hds-message__description", className as undefined)}
+        ref={ref}
+        {...rest}
+      />
+    );
+  },
+);
+MessageDescription.displayName = "MessageDescription";


### PR DESCRIPTION
We have started using this component in the new open tracking beta: https://github.com/bring/open-tracking/pull/269/files

We quickly saw the need for the `Message.Title` and `Message.Description` components to get the style and spacing right.

As a general guideline when it comes to components, when we know the most common use cases we should try to make life easier for the consumers by supporting those.

The great thing about this api is that it's really not in the way, it's opt-in, you can still just render whatever you want. The extra css only applies if you actually use those specific classnames.
