### PR TITLE
:sparkles: make Link overrideable

### DIFF
--- a/.changeset/modern-walls-explode.md
+++ b/.changeset/modern-walls-explode.md
@@ -1,0 +1,6 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+:sparkles: make Link overrideable, so it can be used as a button

--- a/packages/css/src/link/link.css
+++ b/packages/css/src/link/link.css
@@ -78,4 +78,17 @@
       border-color: var(--hds-ui-colors-black-hover);
     }
   }
+
+  &:is(button) {
+    padding: 0;
+    background: none;
+    border-top: 0;
+    border-left: 0;
+    border-right: 0;
+
+    /* Button inherits the font size from the user agent by default  */
+    &:not(.hds-link--small, .hds-link--large) {
+      font: var(--hds-typography-body);
+    }
+  }
 }

--- a/packages/react/src/link/link.stories.tsx
+++ b/packages/react/src/link/link.stories.tsx
@@ -49,3 +49,16 @@ export const NoUnderline: Story = {
     variant: "no-underline",
   },
 };
+
+export const ButtonAsLink: Story = {
+  name: "Button as a link",
+  args: {
+    as: "button",
+    children: "Les mer",
+    href: undefined,
+    onClick: () => {
+      // eslint-disable-next-line no-alert -- Story
+      alert(`Hello world`);
+    },
+  },
+};

--- a/packages/react/src/link/link.tsx
+++ b/packages/react/src/link/link.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname/index.mjs";
+import { forwardRef } from "react";
+import type { OverridableComponent } from "../utils";
 
 export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   /**
@@ -16,33 +18,25 @@ export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement>
   anchorRef?: React.ForwardedRef<HTMLAnchorElement>;
 }
 
-/**
- * ## TODO
- *
- * - [ ] Handle button styling
- */
-export function Link({
-  children,
-  variant = "underline",
-  size = "medium",
-  anchorRef,
-  className,
-  ...rest
-}: LinkProps) {
-  return (
-    <a
-      className={clsx(
-        "hds-link",
-        variant !== "underline" && `hds-link--${variant}`,
-        size !== "medium" && `hds-link--${size}`,
-        className as undefined,
-      )}
-      ref={anchorRef}
-      {...rest}
-    >
-      {children}
-    </a>
-  );
-}
-
+export const Link: OverridableComponent<LinkProps, HTMLAnchorElement> = forwardRef(
+  (
+    { as: Component = "a", children, variant = "underline", size = "medium", className, ...rest },
+    ref,
+  ) => {
+    return (
+      <Component
+        className={clsx(
+          "hds-link",
+          variant !== "underline" && `hds-link--${variant}`,
+          size !== "medium" && `hds-link--${size}`,
+          className as undefined,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+      </Component>
+    );
+  },
+);
 Link.displayName = "Link";


### PR DESCRIPTION
specifically being used as a button

Which we need in `open-tracking` for our current task
![image](https://github.com/bring/hedwig-design-system/assets/244257/d6b0539c-4420-4514-98e5-2f0893b4e7b3)
