### PR TITLE
🔧 Export input component as part of defualt set

### DIFF
--- a/.changeset/weak-emus-yawn.md
+++ b/.changeset/weak-emus-yawn.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-react": patch
+---
+
+Exporting input

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -9,3 +9,4 @@ export * from "./dropdown";
 export * from "./modal";
 export * from "./breadcrumb";
 export * from "./tabs";
+export * from "./input";


### PR DESCRIPTION
# Details

Adding input as part of the default set of exportables on top-level, to enable 👇 

```
import {Input} from '@postenbring/hedwig-react';
```

💥 