### PR TITLE
:memo: Remove single element breadcrumbs in stories, as it should be discouraged

### DIFF
--- a/packages/react/src/breadcrumb/breadcrumb.stories.tsx
+++ b/packages/react/src/breadcrumb/breadcrumb.stories.tsx
@@ -33,6 +33,9 @@ type Story = StoryObj<typeof Breadcrumbs>;
 
 export const Default: Story = {};
 
+/**
+ * You should have at minimum two levels in your hierarchy to use breadcrumbs.
+ */
 export const TwoElements: Story = {
   args: {
     children: (
@@ -41,37 +44,6 @@ export const TwoElements: Story = {
           <Link href="https://www.posten.no">Track letters and parcels</Link>
         </li>
         <li>Shipment from SOMEONE YOU KNOW</li>
-      </>
-    ),
-  },
-};
-
-export const SingleElement: Story = {
-  args: {
-    children: <li>Shipment from SOMEONE YOU KNOW</li>,
-  },
-};
-
-export const LongContent: Story = {
-  args: {
-    children: (
-      <>
-        <li>
-          <Link href="https://www.posten.no">Home</Link>
-        </li>
-        <li>
-          <Link href="https://www.posten.no">Somewhere</Link>
-        </li>
-        <li>
-          <Link href="https://www.posten.no">Deep inside</Link>
-        </li>
-        <li>
-          <Link href="https://www.posten.no">
-            Posten dot no Posten dot no Posten dot no Posten dot no Posten dot no Posten dot no
-            Posten dot no
-          </Link>
-        </li>
-        <li>You will find this page</li>
       </>
     ),
   },


### PR DESCRIPTION
Had a chat with Morten. We agreed too long content in breadcrumbs also should be discouraged.