### PR TITLE
:sparkles: `aria-live: assertive` on error messages

### DIFF
--- a/.changeset/little-seas-compare.md
+++ b/.changeset/little-seas-compare.md
@@ -1,0 +1,7 @@
+---
+"@postenbring/hedwig-react": patch
+---
+
+:sparkles: `aria-live: assertive` on error messages
+
+as discussed with consultant from Inklud.

--- a/packages/react/src/form/error-message/error-message.tsx
+++ b/packages/react/src/form/error-message/error-message.tsx
@@ -5,23 +5,12 @@ export interface ErrorMessageProps {
   children: ReactNode;
   id: string;
   className?: string;
-
-  // We are considering to have aria-live="polite" on field error messages by default.
-  _unstableAriaLiveOnErrorMessage?: boolean;
 }
 
-export function ErrorMessage({
-  children,
-  id,
-  className,
-  _unstableAriaLiveOnErrorMessage,
-}: ErrorMessageProps) {
+export function ErrorMessage({ children, id, className }: ErrorMessageProps) {
   return (
     <div
-      {...(_unstableAriaLiveOnErrorMessage && {
-        "aria-live": "polite",
-        "aria-relevant": "additions removals",
-      })}
+      aria-live="assertive"
       className={clsx("hds-error-message", className as undefined)}
       id={id}
     >

--- a/packages/react/src/form/fieldset/fieldset.stories.tsx
+++ b/packages/react/src/form/fieldset/fieldset.stories.tsx
@@ -19,7 +19,6 @@ export const Default: Story = {
   },
   argTypes: {
     legendProps: { if: { arg: "needThisToHidePropInStorybook", exists: true } },
-    _unstableAriaLiveOnErrorMessage: { if: { arg: "needThisToHidePropInStorybook", exists: true } },
   },
   render: (props) => (
     <Fieldset {...props}>

--- a/packages/react/src/form/fieldset/fieldset.tsx
+++ b/packages/react/src/form/fieldset/fieldset.tsx
@@ -10,9 +10,6 @@ export interface FieldsetProps extends FieldsetHTMLAttributes<HTMLFieldSetElemen
   legendProps?: HTMLAttributes<HTMLElement> & { size: "default" | "large" };
   legend: ReactNode;
   children: ReactNode;
-
-  // We are considering to have aria-live="polite" on field error messages by default.
-  _unstableAriaLiveOnErrorMessage?: boolean;
 }
 
 /**
@@ -26,7 +23,6 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(function 
     legendProps: { size: legendSize = "default", className: legendClassName, ...legendProps } = {},
     legend,
     children,
-    _unstableAriaLiveOnErrorMessage = false,
     ...rest
   },
   ref,
@@ -53,12 +49,7 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(function 
         {legend}
       </legend>
       <div className={clsx("hds-fieldset__input-wrapper")}>{children}</div>
-      <ErrorMessage
-        _unstableAriaLiveOnErrorMessage={_unstableAriaLiveOnErrorMessage}
-        id={errorMessageId}
-      >
-        {errorMessage}
-      </ErrorMessage>
+      <ErrorMessage id={errorMessageId}>{errorMessage}</ErrorMessage>
     </fieldset>
   );
 });

--- a/packages/react/src/form/input-group/input-group.tsx
+++ b/packages/react/src/form/input-group/input-group.tsx
@@ -21,9 +21,6 @@ export interface InputGroupProps {
   disabled?: boolean;
   readOnly?: boolean;
   children: ReactNode;
-
-  // We are considering to have aria-live="polite" on field error messages by default.
-  _unstableAriaLiveOnErrorMessage?: boolean;
 }
 
 export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(function InputGroup(
@@ -38,7 +35,6 @@ export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(function I
     disabled,
     readOnly,
     children,
-    _unstableAriaLiveOnErrorMessage = false,
     ...rest
   },
   ref,
@@ -90,12 +86,7 @@ export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(function I
       >
         {renderInput()}
       </div>
-      <ErrorMessage
-        _unstableAriaLiveOnErrorMessage={_unstableAriaLiveOnErrorMessage}
-        id={errorMessageId}
-      >
-        {errorMessage}
-      </ErrorMessage>
+      <ErrorMessage id={errorMessageId}>{errorMessage}</ErrorMessage>
     </div>
   );
 });

--- a/packages/react/src/form/input/input.stories.tsx
+++ b/packages/react/src/form/input/input.stories.tsx
@@ -193,14 +193,9 @@ export const FormWithErrorsOnSubmit: Story = {
         style={{ display: "flex", flexDirection: "column", gap: "var(--hds-spacing-small-4)" }}
       >
         <p>Fields without input will give an error</p>
-        <Input _unstableAriaLiveOnErrorMessage errorMessage={errors.One} label="One" name="One" />
-        <Input _unstableAriaLiveOnErrorMessage errorMessage={errors.Two} label="Two" name="Two" />
-        <Input
-          _unstableAriaLiveOnErrorMessage
-          errorMessage={errors.Three}
-          label="Three"
-          name="Three"
-        />
+        <Input errorMessage={errors.One} label="One" name="One" />
+        <Input errorMessage={errors.Two} label="Two" name="Two" />
+        <Input errorMessage={errors.Three} label="Three" name="Three" />
         <div
           style={{ display: "flex", flexDirection: "column", gap: "var(--hds-spacing-small-1)" }}
         >

--- a/packages/react/src/form/input/input.tsx
+++ b/packages/react/src/form/input/input.tsx
@@ -7,24 +7,11 @@ import type { InputGroupProps } from "../input-group";
 export type InputProps = Omit<InputGroupProps & InputHTMLAttributes<HTMLInputElement>, "children">;
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  {
-    className,
-    variant,
-    errorMessage,
-    labelProps,
-    label,
-    id,
-    style,
-    disabled,
-    readOnly,
-    _unstableAriaLiveOnErrorMessage,
-    ...rest
-  },
+  { className, variant, errorMessage, labelProps, label, id, style, disabled, readOnly, ...rest },
   ref,
 ) {
   return (
     <InputGroup
-      _unstableAriaLiveOnErrorMessage={_unstableAriaLiveOnErrorMessage}
       className={clsx("hds-input", className as undefined)}
       disabled={disabled}
       errorMessage={errorMessage}


### PR DESCRIPTION
as discussed with consultant from Inklud.