### PR TITLE
Export ErrorMessage component and add stories for storybook

### DIFF
--- a/packages/css/src/form/error-message/error-message.css
+++ b/packages/css/src/form/error-message/error-message.css
@@ -1,7 +1,7 @@
 .hds-error-message {
   font: var(--hds-typography-caption-title);
   color: var(--hds-ui-colors-dark-grey);
-  padding: var(--hds-spacing-small-1) 0 0 var(--hds-spacing-medium-4);
+  padding: var(--hds-spacing-small-2) 0 0 var(--hds-spacing-medium-4);
 
   /* Avoid spacing when no errors are active, but keep the element always in DOM so `aria-live` works */
   &:empty {
@@ -12,6 +12,6 @@
     background-image: url('data:image/svg+xml,<svg fill="none" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><rect fill="black" height="12" rx="3" width="6" x="9" y="7" /><path d="M22.3552 18.4687C22.998 19.5938 22.1944 21 20.8685 21H3.7123C2.38641 21 1.58283 19.5938 2.22569 18.4687L10.8239 3.84375C11.4668 2.71875 13.1141 2.71875 13.7971 3.84375L22.3552 18.4687ZM11.3462 8.46429V13.6071C11.3462 14.1696 11.8284 14.5714 12.3105 14.5714C12.8328 14.5714 13.2748 14.1696 13.2748 13.6071V8.46429C13.2748 7.94196 12.8328 7.5 12.3105 7.5C11.748 7.5 11.3462 7.94196 11.3462 8.46429ZM12.3105 18.4286C12.9935 18.4286 13.556 17.8661 13.556 17.183C13.556 16.5 12.9935 15.9375 12.3105 15.9375C11.5873 15.9375 11.0248 16.5 11.0248 17.183C11.0248 17.8661 11.5873 18.4286 12.3105 18.4286Z" fill="%23FDBB2F" /></svg>');
     background-repeat: no-repeat;
     background-position-x: var(--hds-spacing-small-2);
-    background-position-y: top;
+    background-position-y: var(--hds-spacing-small-1);
   }
 }

--- a/packages/css/src/form/fieldset/fieldset.css
+++ b/packages/css/src/form/fieldset/fieldset.css
@@ -1,7 +1,6 @@
 .hds-fieldset {
   display: flex;
   flex-flow: column nowrap;
-  gap: var(--hds-spacing-small-1);
   border: 0;
   margin: 0;
   padding: 0;

--- a/packages/react/src/form/error-message/error-message.stories.tsx
+++ b/packages/react/src/form/error-message/error-message.stories.tsx
@@ -1,0 +1,35 @@
+/* eslint-disable import/no-extraneous-dependencies -- storybook story */
+import type { Meta, StoryObj } from "@storybook/react";
+import { Checkbox } from "../checkbox";
+import { ErrorMessage } from ".";
+
+const meta: Meta<typeof ErrorMessage> = {
+  title: "ErrorMessage",
+  component: ErrorMessage,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ErrorMessage>;
+
+export const Default: Story = {
+  args: {
+    id: "id",
+    children: "This is an error message for use with form input components",
+  },
+};
+
+export const CheckboxWithErrorMessage: Story = {
+  args: {
+    id: "errorMessageId",
+    children: "This checkbox has an error",
+  },
+  render: (props) => (
+    <>
+      <Checkbox hasError value="Hello" aria-describedby="errorMessageId">
+        Hello
+      </Checkbox>
+      <ErrorMessage id={props.id}>{props.children}</ErrorMessage>
+    </>
+  ),
+};

--- a/packages/react/src/form/index.tsx
+++ b/packages/react/src/form/index.tsx
@@ -4,3 +4,4 @@ export * from "./select";
 export * from "./textarea";
 export * from "./checkbox";
 export * from "./radiobutton";
+export * from "./error-message";


### PR DESCRIPTION
To use a single checkbox without fieldset, we need to export the ErrorMessage component. I also added some stories for the storybook for ErrorMessage.

![image](https://github.com/bring/hedwig-design-system/assets/42927856/275023e9-8fd3-44f1-a036-c26dcdeb1300)
