### PR TITLE
Remove excessive padding and make radio/check label easier on screen readers

### DIFF
--- a/.changeset/tall-forks-learn.md
+++ b/.changeset/tall-forks-learn.md
@@ -1,0 +1,6 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+Remove excessive padding and make radio/check label easier on screen readers

--- a/packages/css/src/form/checkbox/checkbox.css
+++ b/packages/css/src/form/checkbox/checkbox.css
@@ -1,8 +1,6 @@
 .hds-checkbox {
   display: block;
-  min-height: calc(var(--hds-spacing-small-4) * 2 + var(--hds-line-height-body-small-min));
-  padding: var(--hds-spacing-small-4) var(--hds-spacing-small-4) var(--hds-spacing-small-4)
-    calc(var(--hds-spacing-small-4) + 36px);
+  padding: 0 0 0 calc(var(--hds-spacing-small-4) + 36px);
   border-radius: var(--hds-border-radius);
   font: var(--hds-typography-body-small);
   position: relative;
@@ -22,10 +20,19 @@
     padding-bottom: var(--hds-spacing-small-3);
   }
 
+  label::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+  }
+
   /**
   * Hide the browser default checkbox
   */
-  > input[type="checkbox"] {
+  input[type="checkbox"] {
     position: absolute;
     opacity: 0;
     height: 0;
@@ -38,14 +45,13 @@
   .hds-checkbox__checkmark {
     margin: var(--hds-spacing-small-1);
     position: absolute;
-    top: 16px;
     left: 16px;
     height: 16px;
     width: 16px;
     border: solid 2px var(--hds-colors-darker);
   }
 
-  > input[type="checkbox"]:checked ~ .hds-checkbox__checkmark::after {
+  input[type="checkbox"]:checked ~ .hds-checkbox__checkmark::after {
     display: block;
   }
 
@@ -67,6 +73,8 @@
   */
   &.hds-checkbox--bounding-box {
     background-color: var(--hds-colors-lighter);
+    padding: var(--hds-spacing-small-4) var(--hds-spacing-small-4) var(--hds-spacing-small-4)
+      calc(var(--hds-spacing-small-4) + 36px);
 
     &.hds-checkbox--error {
       border: solid 1px var(--hds-ui-colors-warning-yellow);
@@ -74,7 +82,7 @@
   }
 
   &.hds-checkbox--error {
-    > .hds-checkbox__checkmark,
+    .hds-checkbox__checkmark,
     .hds-checkbox__checkmark::after {
       border-color: var(--hds-ui-colors-warning-yellow);
     }

--- a/packages/css/src/form/radiobutton/radiobutton.css
+++ b/packages/css/src/form/radiobutton/radiobutton.css
@@ -1,8 +1,6 @@
 .hds-radiobutton {
   display: block;
-  min-height: calc(var(--hds-spacing-small-4) * 2 + var(--hds-line-height-body-small-min));
-  padding: var(--hds-spacing-small-4) var(--hds-spacing-small-4) var(--hds-spacing-small-4)
-    calc(var(--hds-spacing-small-4) + 36px);
+  padding: 0 0 0 calc(var(--hds-spacing-small-4) + 36px);
   border-radius: var(--hds-border-radius);
   font: var(--hds-typography-body-small);
   position: relative;
@@ -22,10 +20,19 @@
     padding-bottom: var(--hds-spacing-small-3);
   }
 
+  label::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+  }
+
   /**
   * Hide the browser default radiobutton
   */
-  > input[type="radio"] {
+  input[type="radio"] {
     position: absolute;
     opacity: 0;
     height: 0;
@@ -38,7 +45,6 @@
   .hds-radiobutton__checkmark {
     margin: var(--hds-spacing-small-1);
     position: absolute;
-    top: 16px;
     left: 16px;
     height: 16px;
     width: 16px;
@@ -46,7 +52,7 @@
     border-radius: 50%;
   }
 
-  > input[type="radio"]:checked ~ .hds-radiobutton__checkmark::after {
+  input[type="radio"]:checked ~ .hds-radiobutton__checkmark::after {
     display: block;
   }
 
@@ -67,8 +73,10 @@
   */
   &.hds-radiobutton--bounding-box {
     background-color: var(--hds-colors-lighter);
+    padding: var(--hds-spacing-small-4) var(--hds-spacing-small-4) var(--hds-spacing-small-4)
+      calc(var(--hds-spacing-small-4) + 36px);
 
-    > .hds-radiobutton__checkmark::after {
+    .hds-radiobutton__checkmark::after {
       background: var(--hds-colors-dark);
     }
 
@@ -78,7 +86,7 @@
   }
 
   &.hds-radiobutton--error {
-    > .hds-radiobutton__checkmark {
+    .hds-radiobutton__checkmark {
       border-color: var(--hds-ui-colors-warning-yellow);
     }
 

--- a/packages/react/src/form/checkbox/checkbox.tsx
+++ b/packages/react/src/form/checkbox/checkbox.tsx
@@ -11,7 +11,7 @@ export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   ({ variant = "plain", hasError, title, children, className, ...rest }, ref) => {
     return (
-      <label
+      <div
         className={clsx(
           "hds-checkbox",
           {
@@ -21,11 +21,13 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           className as undefined,
         )}
       >
-        <input {...rest} aria-invalid={hasError ? true : undefined} ref={ref} type="checkbox" />
-        <span aria-hidden className="hds-checkbox__checkmark" />
-        {title ? <p className="hds-checkbox__title">{title}</p> : null}
-        {children}
-      </label>
+        <label>
+          <input {...rest} aria-invalid={hasError ? true : undefined} ref={ref} type="checkbox" />
+          <span aria-hidden className="hds-checkbox__checkmark" />
+          {title ? <p className="hds-checkbox__title">{title}</p> : children}
+        </label>
+        {title ? children : null}
+      </div>
     );
   },
 );

--- a/packages/react/src/form/radiobutton/radiobutton.tsx
+++ b/packages/react/src/form/radiobutton/radiobutton.tsx
@@ -12,7 +12,7 @@ export interface RadiobuttonProps
 export const Radiobutton = forwardRef<HTMLInputElement, RadiobuttonProps>(
   ({ variant = "plain", hasError, title, children, className, ...rest }, ref) => {
     return (
-      <label
+      <div
         className={clsx(
           "hds-radiobutton",
           {
@@ -22,11 +22,13 @@ export const Radiobutton = forwardRef<HTMLInputElement, RadiobuttonProps>(
           className as undefined,
         )}
       >
-        <input {...rest} ref={ref} type="radio" />
-        <span aria-hidden className="hds-radiobutton__checkmark" />
-        {title ? <p className="hds-radiobutton__title">{title}</p> : null}
-        {children}
-      </label>
+        <label>
+          <input {...rest} ref={ref} type="radio" />
+          <span aria-hidden className="hds-radiobutton__checkmark" />
+          {title ? <p className="hds-radiobutton__title">{title}</p> : children}
+        </label>
+        {title ? children : null}
+      </div>
     );
   },
 );


### PR DESCRIPTION
## Label is easier on screen readers
When a title is present, the children of radiobutton and checkbox is now moved outside the `<label>`. This gives a better experience with screen readers. With some CSS magic we can still make the entire area clickable just like before.

## Remove excessive padding
### Before
Excessive padding on normal radiobuttons.
![image](https://github.com/bring/hedwig-design-system/assets/435037/436144ed-f7a5-4486-94f7-00c38b578e3f)
![image](https://github.com/bring/hedwig-design-system/assets/435037/597a3180-ea59-4280-ab42-0cbb57818ef3)

### After
No extra padding on normal radiobuttons. Bounding-box variant should be untouched.
![image](https://github.com/bring/hedwig-design-system/assets/435037/d5fb6ccd-9310-4290-a7e8-c9eda3561fe3)
![image](https://github.com/bring/hedwig-design-system/assets/435037/6106792b-c3bf-4b9c-b631-0b215c290aef)