### PR TITLE
:fire: remove no-bullets variant from the list component.

### DIFF
--- a/.changeset/wet-dingos-grab.md
+++ b/.changeset/wet-dingos-grab.md
@@ -1,0 +1,14 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+:fire: remove no-bullets variant from the list component.
+
+people should rather use the ordered or unordered list components with the visual counter or bullet points.
+
+if the need something extra they need to style that themself using `ul`
+
+the special link-list component does just that.
+
+decided during hedwig meeting 14. march 2024

--- a/packages/css/src/list/list.css
+++ b/packages/css/src/list/list.css
@@ -36,18 +36,6 @@
   }
 
   /**
-   * Modifers: Style
-   */
-  &.hds-list--no-bullets {
-    list-style: none;
-    padding-left: 0;
-
-    & li {
-      padding-left: 0;
-    }
-  }
-
-  /**
    * Modifers: Sizes
    */
   &.hds-list--small {
@@ -65,9 +53,19 @@
     gap: var(--hds-spacing-small-3);
   }
 
+  /**
+   * Link list
+   */
   &.hds-list--link-list {
     li:not(:last-child) {
       margin-bottom: var(--hds-spacing-small-2);
+    }
+
+    list-style: none;
+    padding-left: 0;
+
+    & li {
+      padding-left: 0;
     }
   }
 }

--- a/packages/react/src/list/link-list.stories.tsx
+++ b/packages/react/src/list/link-list.stories.tsx
@@ -32,7 +32,7 @@ export const LinkListStory: Story = {
 };
 
 const meta: Meta<typeof LinkList> = {
-  title: "List/LinkList",
+  title: "Link List",
   component: LinkList,
 };
 export default meta;

--- a/packages/react/src/list/link-list.tsx
+++ b/packages/react/src/list/link-list.tsx
@@ -7,13 +7,14 @@ export interface LinkListProps extends Omit<ListProps, "listStyle"> {
   children?: React.ReactElement<HTMLLIElement> | React.ReactElement<HTMLLIElement>[];
 }
 
+/**
+ * Show a list of links
+ *
+ * For other list types use `UnorderedList` and `OrderedList`, or use your own list component using the semantic `ul` and `ol` tags.
+ */
 export function LinkList({ className, ...rest }: LinkListProps) {
   return (
-    <UnorderedList
-      className={clsx("hds-list--link-list", className as undefined)}
-      listStyle="no-bullets"
-      {...rest}
-    />
+    <UnorderedList className={clsx("hds-list--link-list", className as undefined)} {...rest} />
   );
 }
 

--- a/packages/react/src/list/list.stories.tsx
+++ b/packages/react/src/list/list.stories.tsx
@@ -54,21 +54,6 @@ export const OrderedListStory: Story = {
   ),
 };
 
-export const NoBulletsListStory: Story = {
-  name: "No Bullets List",
-  args: {
-    listStyle: "no-bullets",
-    children: listItems,
-  },
-  render: (props) => (
-    <HStack>
-      <UnorderedList {...props} size="small" />
-      <UnorderedList {...props} size="medium" />
-      <UnorderedList {...props} size="large" />
-    </HStack>
-  ),
-};
-
 export const NestedLists: Story = {
   render: () => (
     <UnorderedList>

--- a/packages/react/src/list/list.tsx
+++ b/packages/react/src/list/list.tsx
@@ -5,10 +5,6 @@ import { clsx } from "@postenbring/hedwig-css/typed-classname/index.mjs";
 export interface ListProps extends HTMLAttributes<HTMLOListElement | HTMLUListElement> {
   children?: React.ReactElement<HTMLLIElement> | React.ReactElement<HTMLLIElement>[];
   /**
-   * Inherit list styles or do not show these
-   */
-  listStyle?: "inherit" | "no-bullets";
-  /**
    * Sets the size of the items (font)
    */
   size?: "small" | "medium" | "large";
@@ -17,28 +13,22 @@ export interface ListProps extends HTMLAttributes<HTMLOListElement | HTMLUListEl
 function BaseList({
   as: ListTag = "ul",
   children,
-  listStyle = "inherit",
   size = "medium",
   className,
   ...rest
 }: ListProps & { as?: "ul" | "ol" }) {
   return (
-    <ListTag
-      className={clsx(
-        "hds-list",
-        `hds-list--${size}`,
-        {
-          "hds-list--no-bullets": listStyle === "no-bullets",
-        },
-        className as undefined,
-      )}
-      {...rest}
-    >
+    <ListTag className={clsx("hds-list", `hds-list--${size}`, className as undefined)} {...rest}>
       {children}
     </ListTag>
   );
 }
 
+/**
+ * An unordered list of simple items, often text. You can nest other lists inside this component.
+ *
+ * If you have other list needs build your own using the semantic `ul` and `ol` tags.
+ */
 export function UnorderedList(props: ListProps) {
   return (
     <BaseList as="ul" {...props}>
@@ -47,6 +37,11 @@ export function UnorderedList(props: ListProps) {
   );
 }
 
+/**
+ * An ordered list of simple items
+ *
+ * If you have other list needs build your own using the semantic `ul` and `ol` tags.
+ */
 export function OrderedList(props: ListProps) {
   return (
     <BaseList as="ol" {...props}>


### PR DESCRIPTION
people should rather use the ordered or unordered list components with the visual counter or bullet points.

if the need something extra they need to style that themself using `ul`

the special link-list component does just that.

decided during hedwig meeting 14. march 2024