### PR TITLE
More spacing tweaks on radio/check, fix radio dot color, remove disabled from stories

### DIFF
--- a/.changeset/seven-donkeys-happen.md
+++ b/.changeset/seven-donkeys-happen.md
@@ -1,0 +1,12 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+More spacing tweaks on radio/check, fix radio dot color, remove disabled from stories
+
+More spacing tweaks on radiobuttons and checkboxes to make non-bounding-box variant align correctly.
+
+Radiobutton dot color was set to Signature, just like in Figma. However, it turns out Figma was wrong.
+
+Remove disabled variants from stories as we don't want to encourage using them.

--- a/packages/css/src/form/checkbox/checkbox.css
+++ b/packages/css/src/form/checkbox/checkbox.css
@@ -1,6 +1,10 @@
 .hds-checkbox {
+  --checkmark-width: 16px;
+  --checkmark-margin: var(--hds-spacing-small-1);
+
   display: block;
-  padding: 0 0 0 calc(var(--hds-spacing-small-4) + 36px);
+  padding: 0 0 0
+    calc(var(--checkmark-width) + (var(--checkmark-margin) * 2) + var(--hds-spacing-small-3));
   border-radius: var(--hds-border-radius);
   font: var(--hds-typography-body-small);
   position: relative;
@@ -43,11 +47,11 @@
   * Create a custom checkbox
   */
   .hds-checkbox__checkmark {
-    margin: var(--hds-spacing-small-1);
+    margin: var(--checkmark-margin);
     position: absolute;
-    left: 16px;
-    height: 16px;
-    width: 16px;
+    left: 0;
+    height: var(--checkmark-width);
+    width: var(--checkmark-width);
     border: solid 2px var(--hds-colors-darker);
   }
 
@@ -73,8 +77,15 @@
   */
   &.hds-checkbox--bounding-box {
     background-color: var(--hds-colors-lighter);
-    padding: var(--hds-spacing-small-4) var(--hds-spacing-small-4) var(--hds-spacing-small-4)
-      calc(var(--hds-spacing-small-4) + 36px);
+    padding: var(--hds-spacing-small-4) var(--hds-spacing-medium-3) var(--hds-spacing-small-4)
+      calc(
+        var(--hds-spacing-small-4) + var(--checkmark-width) + (var(--checkmark-margin) * 2) +
+          var(--hds-spacing-small-3)
+      );
+
+    .hds-checkbox__checkmark {
+      left: var(--hds-spacing-small-4);
+    }
 
     &.hds-checkbox--error {
       border: solid 1px var(--hds-ui-colors-warning-yellow);

--- a/packages/css/src/form/radiobutton/radiobutton.css
+++ b/packages/css/src/form/radiobutton/radiobutton.css
@@ -1,6 +1,10 @@
 .hds-radiobutton {
+  --checkmark-width: 16px;
+  --checkmark-margin: var(--hds-spacing-small-1);
+
   display: block;
-  padding: 0 0 0 calc(var(--hds-spacing-small-4) + 36px);
+  padding: 0 0 0
+    calc(var(--checkmark-width) + (var(--checkmark-margin) * 2) + var(--hds-spacing-small-3));
   border-radius: var(--hds-border-radius);
   font: var(--hds-typography-body-small);
   position: relative;
@@ -45,9 +49,9 @@
   .hds-radiobutton__checkmark {
     margin: var(--hds-spacing-small-1);
     position: absolute;
-    left: 16px;
-    height: 16px;
-    width: 16px;
+    left: 0;
+    height: var(--checkmark-width);
+    width: var(--checkmark-width);
     border: solid 2px var(--hds-colors-darker);
     border-radius: 50%;
   }
@@ -65,7 +69,7 @@
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--hds-colors-signature);
+    background: var(--hds-colors-dark);
   }
 
   /**
@@ -73,11 +77,14 @@
   */
   &.hds-radiobutton--bounding-box {
     background-color: var(--hds-colors-lighter);
-    padding: var(--hds-spacing-small-4) var(--hds-spacing-small-4) var(--hds-spacing-small-4)
-      calc(var(--hds-spacing-small-4) + 36px);
+    padding: var(--hds-spacing-small-4) var(--hds-spacing-medium-3) var(--hds-spacing-small-4)
+      calc(
+        var(--hds-spacing-small-4) + var(--checkmark-width) + (var(--checkmark-margin) * 2) +
+          var(--hds-spacing-small-3)
+      );
 
-    .hds-radiobutton__checkmark::after {
-      background: var(--hds-colors-dark);
+    .hds-radiobutton__checkmark {
+      left: var(--hds-spacing-small-4);
     }
 
     &.hds-radiobutton--error {

--- a/packages/react/src/form/checkbox/checkbox.stories.tsx
+++ b/packages/react/src/form/checkbox/checkbox.stories.tsx
@@ -23,7 +23,6 @@ export const PlainCheckbox: Story = {
     >
       <Checkbox>This is a checkbox</Checkbox>
       <Checkbox hasError>This is a checkbox with error</Checkbox>
-      <Checkbox disabled>This is a disabled checkbox</Checkbox>
     </div>
   ),
 };
@@ -41,9 +40,6 @@ export const BoundedCheckbox: Story = {
       <Checkbox variant="bounding-box">This is a checkbox with bounding box</Checkbox>
       <Checkbox hasError variant="bounding-box">
         This is a checkbox with bounding box and error
-      </Checkbox>
-      <Checkbox disabled variant="bounding-box">
-        This is a disabled checkbox with bounding box
       </Checkbox>
     </div>
   ),

--- a/packages/react/src/form/radiobutton/radiobutton.stories.tsx
+++ b/packages/react/src/form/radiobutton/radiobutton.stories.tsx
@@ -26,9 +26,6 @@ export const PlainRadiobutton: Story = {
       <Radiobutton hasError name="group1">
         This is a radiobutton with error
       </Radiobutton>
-      <Radiobutton disabled name="group1">
-        This is a disabled radiobutton
-      </Radiobutton>
     </div>
   ),
 };
@@ -48,9 +45,6 @@ export const BoundedRadiobutton: Story = {
       </Radiobutton>
       <Radiobutton hasError name="group2" variant="bounding-box">
         This is a radiobutton with bounding box and error
-      </Radiobutton>
-      <Radiobutton disabled name="group2" variant="bounding-box">
-        This is a disabled radiobutton with bounding box
       </Radiobutton>
     </div>
   ),


### PR DESCRIPTION
## More spacing tweaks on radiobuttons and checkboxes to make non-bounding-box variant align correctly.

### Before
Too much left padding can clearly be seen under a Fieldset legend.
![image](https://github.com/bring/hedwig-design-system/assets/435037/8ee5796f-43c1-4edb-b424-00c1c3bac325)
![image](https://github.com/bring/hedwig-design-system/assets/435037/3b3df0ae-0006-433c-bfaa-e9644914a6b6)

### After
Correct left padding. Bounding box variant should be untouched.
![image](https://github.com/bring/hedwig-design-system/assets/435037/5763dd5a-1df3-4f74-a262-c3cf70e4632e)
![image](https://github.com/bring/hedwig-design-system/assets/435037/91d77231-8fbe-492a-b309-1c290973b574)

## Radiobutton dot color was set to Signature, just like in Figma. However, it turns out Figma was wrong.
The color was wrong in Figma. Radiobutton dots and checkbox checkmarks should alwasy be Dark brand color.

## Remove disabled variants from stories as we don't want to encourage using them.
Disabled state is not something we should use. We will consider removing them entirely down the road, but for now we'll at least remove them from stories.