### PR TITLE
Fix bug in condition for fullWidth on mobile

### DIFF
--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -70,7 +70,7 @@ export const BaseButton: OverridableComponent<
           {
             [`hds-button--${variant}`]: fill === "contained",
             [`hds-button--outline-${variant}`]: fill === "outline" || fill === "outlined",
-            "hds-button--full": fullWidth,
+            "hds-button--full": fullWidth === true,
             "hds-button--mobile-full": fullWidth === "mobile",
             "hds-button--icon-only": icon && !children,
           },


### PR DESCRIPTION
# Details

Small fix for condition for full width button on mobile. 

Buttons have the property ` fullWidth: boolean | "mobile"`. 

When this is used as a condition for the css classes, we previously had `"hds-button--full": fullWidth === true`. The IDE complains about this and states that the `=== true` is not necessary. However, that is not the case, because for `fullWidth = 'mobile'`, we should not have the hds-button--full. 

To solve this, I have added the `=== true` again. 

![image](https://github.com/bring/hedwig-design-system/assets/42927856/0a96e6d1-181f-461f-8de5-da0fe614c4ac)
