### PR TITLE
Add capability to Checkbox to display error message

### DIFF
--- a/.changeset/cuddly-comics-happen.md
+++ b/.changeset/cuddly-comics-happen.md
@@ -1,0 +1,11 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+Add capability to Checkbox to display error message
+
+This change adds the prop `errorMessage` which takes a `ReactNode`.
+You should now only use `hasError` when your checkbox is part of a fieldset which will show the error message.
+Use `errorMessage` when your checkbox is standalone (not part of a fieldset). Doing this will add error styling,
+and display the error message. The component will take care of aria to connect the error message to the checkbox.

--- a/packages/css/src/form/checkbox/checkbox.css
+++ b/packages/css/src/form/checkbox/checkbox.css
@@ -1,3 +1,9 @@
+.hds-checkbox-wrapper {
+  display: flex;
+  flex-flow: column nowrap;
+  gap: var(--hds-spacing-8);
+}
+
 .hds-checkbox {
   --checkmark-width: 16px;
   --checkmark-margin: var(--hds-spacing-4);

--- a/packages/react/src/form/checkbox/checkbox.stories.tsx
+++ b/packages/react/src/form/checkbox/checkbox.stories.tsx
@@ -17,8 +17,11 @@ export const JustACheckbox: Story = {
     title: "",
     children: "Just a checkbox",
     checked: true,
-    hasError: false,
+    errorMessage: "",
     variant: "plain",
+    onChange: () => {
+      /**/
+    },
   },
   argTypes: {
     variant: { control: "inline-radio", options: ["plain", "bounding-box"] },
@@ -37,6 +40,9 @@ export const PlainCheckbox: Story = {
     >
       <Checkbox>This is a checkbox</Checkbox>
       <Checkbox hasError>This is a checkbox with error</Checkbox>
+      <Checkbox errorMessage="Something is wrong">
+        This is a checkbox with an error message
+      </Checkbox>
     </div>
   ),
 };
@@ -52,7 +58,7 @@ export const BoundedCheckbox: Story = {
       }}
     >
       <Checkbox variant="bounding-box">This is a checkbox with bounding box</Checkbox>
-      <Checkbox hasError variant="bounding-box">
+      <Checkbox errorMessage="Something is wrong" variant="bounding-box">
         This is a checkbox with bounding box and error
       </Checkbox>
     </div>
@@ -70,7 +76,7 @@ export const DetailedContentCheckbox: Story = {
       }}
     >
       <Checkbox title="Check this box">Detailed description if needed</Checkbox>
-      <Checkbox hasError title="Check box with error">
+      <Checkbox errorMessage="Something is wrong" title="Checkbox with error">
         Detailed description if needed
       </Checkbox>
     </div>
@@ -90,7 +96,11 @@ export const DetailedContentCheckboxWithBoundingBox: Story = {
       <Checkbox title="Check this box" variant="bounding-box">
         Detailed description if needed
       </Checkbox>
-      <Checkbox hasError title="Check box with error" variant="bounding-box">
+      <Checkbox
+        errorMessage="Something is wrong"
+        title="Checkbox with error"
+        variant="bounding-box"
+      >
         Detailed description if needed
       </Checkbox>
     </div>

--- a/packages/react/src/form/checkbox/checkbox.tsx
+++ b/packages/react/src/form/checkbox/checkbox.tsx
@@ -1,32 +1,63 @@
-import type { InputHTMLAttributes } from "react";
-import React, { forwardRef } from "react";
+import { forwardRef, useId, type InputHTMLAttributes, type ReactNode } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
+import { ErrorMessage } from "../error-message";
 
-export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "defaultValue"> {
+export type CheckboxProps = Omit<InputHTMLAttributes<HTMLInputElement>, "defaultValue"> & {
+  children: ReactNode;
   variant?: "plain" | "bounding-box";
-  hasError?: boolean;
   title?: string;
-}
+} & (
+    | {
+        /**
+         * Set to `true` to add error styling. The component will take care of aria to indicate invalid state.
+         *
+         * Use this when your checkbox is part of a fieldset which shows an error message.
+         */
+        hasError?: boolean;
+        errorMessage?: never;
+      }
+    | {
+        hasError?: never;
+        /**
+         * Set an error message to add error styling, and display the error message.
+         * The component will take care of aria to connect the error message to the checkbox.
+         *
+         * Use this when your checkbox is standalone (not part of a fieldset).
+         */
+        errorMessage?: ReactNode;
+      }
+  );
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ variant = "plain", hasError, title, children, className, ...rest }, ref) => {
+  ({ variant = "plain", hasError, errorMessage, title, children, className, ...rest }, ref) => {
+    const errorMessageId = useId();
+
     return (
-      <div
-        className={clsx(
-          "hds-checkbox",
-          {
-            [`hds-checkbox--${variant}`]: variant === "bounding-box",
-            "hds-checkbox--error": hasError,
-          },
-          className as undefined,
-        )}
-      >
-        <label>
-          <input {...rest} aria-invalid={hasError ? true : undefined} ref={ref} type="checkbox" />
-          <span aria-hidden className="hds-checkbox__checkmark" />
-          {title ? <p className="hds-checkbox__title">{title}</p> : children}
-        </label>
-        {title ? children : null}
+      <div className={clsx("hds-checkbox-wrapper")}>
+        <div
+          className={clsx(
+            "hds-checkbox",
+            {
+              [`hds-checkbox--${variant}`]: variant === "bounding-box",
+              "hds-checkbox--error": hasError ?? errorMessage,
+            },
+            className as undefined,
+          )}
+        >
+          <label>
+            <input
+              {...rest}
+              aria-invalid={hasError ?? errorMessage ? true : undefined}
+              aria-describedby={errorMessage ? errorMessageId : undefined}
+              ref={ref}
+              type="checkbox"
+            />
+            <span aria-hidden className="hds-checkbox__checkmark" />
+            {title ? <p className="hds-checkbox__title">{title}</p> : children}
+          </label>
+          {title ? children : null}
+        </div>
+        {errorMessage ? <ErrorMessage id={errorMessageId}>{errorMessage}</ErrorMessage> : null}
       </div>
     );
   },

--- a/packages/react/src/form/error-message/error-message.stories.tsx
+++ b/packages/react/src/form/error-message/error-message.stories.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies -- storybook story */
 import type { Meta, StoryObj } from "@storybook/react";
-import { Checkbox } from "../checkbox";
 import { ErrorMessage } from ".";
 
 const meta: Meta<typeof ErrorMessage> = {
@@ -17,19 +16,4 @@ export const Default: Story = {
     id: "id",
     children: "This is an error message for use with form input components",
   },
-};
-
-export const CheckboxWithErrorMessage: Story = {
-  args: {
-    id: "errorMessageId",
-    children: "This checkbox has an error",
-  },
-  render: (props) => (
-    <>
-      <Checkbox hasError value="Hello" aria-describedby="errorMessageId">
-        Hello
-      </Checkbox>
-      <ErrorMessage id={props.id}>{props.children}</ErrorMessage>
-    </>
-  ),
 };


### PR DESCRIPTION
This change adds the prop `errorMessage` which takes a `ReactNode`.
You should now only use `hasError` when your checkbox is part of a fieldset which will show the error message.
Use `errorMessage` when your checkbox is standalone (not part of a fieldset). Doing this will add error styling,
and display the error message. The component will take care of aria to connect the error message to the checkbox.