### PR TITLE
Add context in Fieldset to give error state to contained components

### DIFF
--- a/.changeset/tidy-seahorses-count.md
+++ b/.changeset/tidy-seahorses-count.md
@@ -1,0 +1,10 @@
+---
+"@postenbring/hedwig-react": patch
+---
+
+Add context in Fieldset to give error state to contained components
+
+Providing an errorMessage to Fieldset will now also give contained Checkboxes or Radiobuttons
+error styling and aria to indicate invalid state.
+
+For Radiobuttons you are even better off using the already existing RadioGroup.

--- a/packages/react/src/form/checkbox/checkbox.stories.tsx
+++ b/packages/react/src/form/checkbox/checkbox.stories.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies -- storybook story */
 import type { Meta, StoryObj } from "@storybook/react";
+import { Fieldset } from "../fieldset";
 import { Checkbox } from "./index";
 
 const meta: Meta<typeof Checkbox> = {
@@ -28,23 +29,35 @@ export const JustACheckbox: Story = {
   },
 };
 
-export const PlainCheckbox: Story = {
+export const PlainCheckboxes: Story = {
   name: "Checkboxes",
   render: (_props) => (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: "var(--hds-spacing-4)",
-      }}
+    <Fieldset legend="Checkboxes should be grouped in a Fieldset">
+      <Checkbox>This is a checkbox</Checkbox>
+      <Checkbox>This is another checkbox</Checkbox>
+    </Fieldset>
+  ),
+};
+
+export const PlainCheckboxesWithError: Story = {
+  name: "Checkboxes with error",
+  render: (_props) => (
+    <Fieldset
+      legend="Fieldset will aid you with styling and aria when it is provided an error message"
+      errorMessage="Something is wrong"
     >
       <Checkbox>This is a checkbox</Checkbox>
-      <Checkbox hasError>This is a checkbox with error</Checkbox>
-      <Checkbox errorMessage="Something is wrong">
-        This is a checkbox with an error message
-      </Checkbox>
-    </div>
+      <Checkbox>This is another checkbox</Checkbox>
+    </Fieldset>
   ),
+};
+
+export const PlainCheckboxeWithError: Story = {
+  name: "Standalone checkbox with error message",
+  args: {
+    errorMessage: "Something is wrong",
+    children: "This is a checkbox with an error message",
+  },
 };
 
 export const BoundedCheckbox: Story = {
@@ -54,7 +67,7 @@ export const BoundedCheckbox: Story = {
       style={{
         display: "flex",
         flexDirection: "column",
-        gap: "var(--hds-spacing-4)",
+        gap: "var(--hds-spacing-8)",
       }}
     >
       <Checkbox variant="bounding-box">This is a checkbox with bounding box</Checkbox>
@@ -72,7 +85,7 @@ export const DetailedContentCheckbox: Story = {
       style={{
         display: "flex",
         flexDirection: "column",
-        gap: "var(--hds-spacing-4)",
+        gap: "var(--hds-spacing-8)",
       }}
     >
       <Checkbox title="Check this box">Detailed description if needed</Checkbox>
@@ -90,7 +103,7 @@ export const DetailedContentCheckboxWithBoundingBox: Story = {
       style={{
         display: "flex",
         flexDirection: "column",
-        gap: "var(--hds-spacing-4)",
+        gap: "var(--hds-spacing-8)",
       }}
     >
       <Checkbox title="Check this box" variant="bounding-box">

--- a/packages/react/src/form/checkbox/checkbox.tsx
+++ b/packages/react/src/form/checkbox/checkbox.tsx
@@ -46,8 +46,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     ref,
   ) => {
     const errorMessageId = useId();
-    const { errorMessage: errorMessageContext } = useFieldsetContext();
-    const hasError = !!errorMessage || !!errorMessageContext || hasErrorProp;
+    const { hasError: hasFieldsetError } = useFieldsetContext();
+    const hasError = !!errorMessage || hasFieldsetError || hasErrorProp;
 
     return (
       <div className={clsx("hds-checkbox-wrapper")}>

--- a/packages/react/src/form/checkbox/checkbox.tsx
+++ b/packages/react/src/form/checkbox/checkbox.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useId, type InputHTMLAttributes, type ReactNode } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
 import { ErrorMessage } from "../error-message";
+import { useFieldsetContext } from "../fieldset";
 
 export type CheckboxProps = Omit<InputHTMLAttributes<HTMLInputElement>, "defaultValue"> & {
   children: ReactNode;
@@ -11,7 +12,10 @@ export type CheckboxProps = Omit<InputHTMLAttributes<HTMLInputElement>, "default
         /**
          * Set to `true` to add error styling. The component will take care of aria to indicate invalid state.
          *
-         * Use this when your checkbox is part of a fieldset which shows an error message.
+         * Normally you don't need this, as you should wrap your Checkboxes in the Fieldset component.
+         * When providing an errorMessage to Fieldset, all contained Checkboxes will get correct hasError state.
+         *
+         * You can use this when your checkbox is part of a non-HDS fieldset which shows an error message.
          */
         hasError?: boolean;
         errorMessage?: never;
@@ -29,8 +33,21 @@ export type CheckboxProps = Omit<InputHTMLAttributes<HTMLInputElement>, "default
   );
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ variant = "plain", hasError, errorMessage, title, children, className, ...rest }, ref) => {
+  (
+    {
+      variant = "plain",
+      hasError: hasErrorProp,
+      errorMessage,
+      title,
+      children,
+      className,
+      ...rest
+    },
+    ref,
+  ) => {
     const errorMessageId = useId();
+    const { errorMessage: errorMessageContext } = useFieldsetContext();
+    const hasError = !!errorMessage || !!errorMessageContext || hasErrorProp;
 
     return (
       <div className={clsx("hds-checkbox-wrapper")}>
@@ -39,7 +56,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             "hds-checkbox",
             {
               [`hds-checkbox--${variant}`]: variant === "bounding-box",
-              "hds-checkbox--error": hasError ?? errorMessage,
+              "hds-checkbox--error": hasError,
             },
             className as undefined,
           )}
@@ -47,7 +64,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           <label>
             <input
               {...rest}
-              aria-invalid={hasError ?? errorMessage ? true : undefined}
+              aria-invalid={hasError ? true : undefined}
               aria-describedby={errorMessage ? errorMessageId : undefined}
               ref={ref}
               type="checkbox"

--- a/packages/react/src/form/fieldset/fieldset.stories.tsx
+++ b/packages/react/src/form/fieldset/fieldset.stories.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies -- storybook story */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Checkbox } from "../checkbox";
+import { Radiobutton } from "../radiobutton";
 import { Fieldset } from ".";
 
 const meta: Meta<typeof Fieldset> = {
@@ -44,22 +45,42 @@ export const LargeLegend: Story = {
   ),
 };
 
-export const FieldsetError: Story = {
+export const FieldsetErrorCheckboxes: Story = {
   args: {
-    legend: "Fieldset with error message",
+    legend: "Checkboxes wrapped in Fieldset will get error styling when Fieldset has errorMessage",
     errorMessage: "Something's wrong",
   },
   render: (props) => (
     <Fieldset {...props}>
-      <Checkbox hasError value="Hello">
+      <Checkbox value="Hello">Hello</Checkbox>
+      <Checkbox value="Hello">Hello</Checkbox>
+      <Checkbox value="Hello">Hello</Checkbox>
+    </Fieldset>
+  ),
+};
+
+export const FieldsetErrorRadiobuttons: Story = {
+  args: {
+    legend: (
+      <>
+        Radiobuttons wrapped in Fieldset will get error styling when Fieldset has errorMessage
+        <br />
+        However, you should probably use RadioGroup instead of Fieldset for Radiobuttons
+      </>
+    ),
+    errorMessage: "Something's wrong",
+  },
+  render: (props) => (
+    <Fieldset {...props}>
+      <Radiobutton value="Hello" name="radiogroup">
         Hello
-      </Checkbox>
-      <Checkbox hasError value="Hello">
+      </Radiobutton>
+      <Radiobutton value="Hello" name="radiogroup">
         Hello
-      </Checkbox>
-      <Checkbox hasError value="Hello">
+      </Radiobutton>
+      <Radiobutton value="Hello" name="radiogroup">
         Hello
-      </Checkbox>
+      </Radiobutton>
     </Fieldset>
   ),
 };

--- a/packages/react/src/form/fieldset/fieldset.tsx
+++ b/packages/react/src/form/fieldset/fieldset.tsx
@@ -18,7 +18,7 @@ export interface FieldsetProps extends FieldsetHTMLAttributes<HTMLFieldSetElemen
   children: ReactNode;
 }
 
-const FieldsetContext = createContext<{ errorMessage?: ReactNode }>({});
+const FieldsetContext = createContext<{ hasError: boolean }>({ hasError: false });
 
 export const useFieldsetContext = () => useContext(FieldsetContext);
 
@@ -56,7 +56,9 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(function 
         {legend}
       </legend>
       <div className={clsx("hds-fieldset__input-wrapper")}>
-        <FieldsetContext.Provider value={{ errorMessage }}>{children}</FieldsetContext.Provider>
+        <FieldsetContext.Provider value={{ hasError: Boolean(errorMessage) }}>
+          {children}
+        </FieldsetContext.Provider>
       </div>
       <ErrorMessage id={errorMessageId}>{errorMessage}</ErrorMessage>
     </fieldset>

--- a/packages/react/src/form/fieldset/fieldset.tsx
+++ b/packages/react/src/form/fieldset/fieldset.tsx
@@ -1,4 +1,4 @@
-import { useId, forwardRef } from "react";
+import { useId, forwardRef, createContext, useContext } from "react";
 import type { FieldsetHTMLAttributes, HTMLAttributes, ReactNode, CSSProperties } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
 import { ErrorMessage } from "../error-message";
@@ -6,11 +6,21 @@ import { ErrorMessage } from "../error-message";
 export interface FieldsetProps extends FieldsetHTMLAttributes<HTMLFieldSetElement> {
   className?: string;
   style?: CSSProperties;
+  /**
+   * Providing an errorMessage will also give contained Checkboxes or Radiobuttons
+   * error styling and aria to indicate invalid state.
+   *
+   * For Radiobuttons you are even better off using RadioGroup.
+   */
   errorMessage?: ReactNode;
   legendProps?: HTMLAttributes<HTMLElement> & { size: "default" | "large" };
   legend: ReactNode;
   children: ReactNode;
 }
+
+const FieldsetContext = createContext<{ errorMessage?: ReactNode }>({});
+
+export const useFieldsetContext = () => useContext(FieldsetContext);
 
 export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(function Fieldset(
   {
@@ -45,7 +55,9 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(function 
       >
         {legend}
       </legend>
-      <div className={clsx("hds-fieldset__input-wrapper")}>{children}</div>
+      <div className={clsx("hds-fieldset__input-wrapper")}>
+        <FieldsetContext.Provider value={{ errorMessage }}>{children}</FieldsetContext.Provider>
+      </div>
       <ErrorMessage id={errorMessageId}>{errorMessage}</ErrorMessage>
     </fieldset>
   );

--- a/packages/react/src/form/fieldset/index.tsx
+++ b/packages/react/src/form/fieldset/index.tsx
@@ -1,2 +1,2 @@
-export { Fieldset } from "./fieldset";
+export { Fieldset, useFieldsetContext } from "./fieldset";
 export type * from "./fieldset";

--- a/packages/react/src/form/radiobutton/index.tsx
+++ b/packages/react/src/form/radiobutton/index.tsx
@@ -1,4 +1,4 @@
 export { Radiobutton } from "./radiobutton";
 export type * from "./radiobutton";
-export { RadioGroup } from "./radiogroup";
+export { RadioGroup, useRadioGroupContext } from "./radiogroup";
 export type * from "./radiogroup";

--- a/packages/react/src/form/radiobutton/radiobutton.stories.tsx
+++ b/packages/react/src/form/radiobutton/radiobutton.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies -- storybook story */
 import type { Meta, StoryObj } from "@storybook/react";
-import { Radiobutton } from "./index";
+import { Radiobutton, RadioGroup } from "./index";
 
 const meta: Meta<typeof Radiobutton> = {
   title: "Form/Radiobutton/Radiobutton",
@@ -12,10 +12,10 @@ export default meta;
 type Story = StoryObj<typeof Radiobutton>;
 
 export const JustARadiobutton: Story = {
-  name: "Just a radio button",
+  name: "Just a radiobutton",
   args: {
     title: "",
-    children: "Just a radio button",
+    children: "Just a radiobutton",
     checked: true,
     hasError: false,
     variant: "plain",
@@ -25,33 +25,38 @@ export const JustARadiobutton: Story = {
   },
 };
 
-export const PlainRadiobutton: Story = {
-  name: "Radio buttons",
+export const PlainRadiobuttons: Story = {
+  name: "Radiobuttons",
   render: (_props) => (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: "var(--hds-spacing-4)",
-      }}
-      role="radiogroup"
+    <RadioGroup legend="Radiobuttons should be grouped in a RadioGroup" name="group1">
+      <Radiobutton>This is a radiobutton</Radiobutton>
+      <Radiobutton>This is another radiobutton</Radiobutton>
+    </RadioGroup>
+  ),
+};
+
+export const PlainRadiobuttonsWithError: Story = {
+  name: "Radiobuttons with error",
+  render: (_props) => (
+    <RadioGroup
+      legend="RadioGroup will aid you with styling and aria when it is provided an error message"
+      errorMessage="Something is wrong"
+      name="group1error"
     >
-      <Radiobutton name="group1">This is a radiobutton</Radiobutton>
-      <Radiobutton hasError name="group1">
-        This is a radiobutton with error
-      </Radiobutton>
-    </div>
+      <Radiobutton>This is a radiobutton</Radiobutton>
+      <Radiobutton>This is another radiobutton</Radiobutton>
+    </RadioGroup>
   ),
 };
 
 export const BoundedRadiobutton: Story = {
-  name: "Radio buttons with bounding box",
+  name: "Radiobuttons with bounding box",
   render: (_props) => (
     <div
       style={{
         display: "flex",
         flexDirection: "column",
-        gap: "var(--hds-spacing-4)",
+        gap: "var(--hds-spacing-8)",
       }}
       role="radiogroup"
     >
@@ -66,13 +71,13 @@ export const BoundedRadiobutton: Story = {
 };
 
 export const DetailedContentRadiobutton: Story = {
-  name: "Radio buttons with title",
+  name: "Radiobuttons with title",
   render: (_props) => (
     <div
       style={{
         display: "flex",
         flexDirection: "column",
-        gap: "var(--hds-spacing-4)",
+        gap: "var(--hds-spacing-8)",
       }}
       role="radiogroup"
     >
@@ -87,13 +92,13 @@ export const DetailedContentRadiobutton: Story = {
 };
 
 export const DetailedContentRadiobuttonWithBoundingBox: Story = {
-  name: "Radio buttons with bounding box and title",
+  name: "Radiobuttons with bounding box and title",
   render: (_props) => (
     <div
       style={{
         display: "flex",
         flexDirection: "column",
-        gap: "var(--hds-spacing-4)",
+        gap: "var(--hds-spacing-8)",
       }}
       role="radiogroup"
     >

--- a/packages/react/src/form/radiobutton/radiobutton.tsx
+++ b/packages/react/src/form/radiobutton/radiobutton.tsx
@@ -45,9 +45,13 @@ export const Radiobutton = forwardRef<HTMLInputElement, RadiobuttonProps>(
     },
     ref,
   ) => {
-    const { value: selectedValue, hasError: hasErrorContext, ...context } = useRadioGroupContext();
-    const { errorMessage: errorMessageContext } = useFieldsetContext();
-    const hasError = !!errorMessageContext || hasErrorContext || hasErrorProp;
+    const {
+      value: selectedValue,
+      hasError: hasRadioGroupError,
+      ...context
+    } = useRadioGroupContext();
+    const { hasError: hasFieldsetError } = useFieldsetContext();
+    const hasError = hasFieldsetError || hasRadioGroupError || hasErrorProp;
 
     return (
       <div

--- a/packages/react/src/form/radiobutton/radiobutton.tsx
+++ b/packages/react/src/form/radiobutton/radiobutton.tsx
@@ -1,11 +1,20 @@
 import { forwardRef, type InputHTMLAttributes, type ReactNode } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
+import { useFieldsetContext } from "../fieldset";
 import { type RadioGroupProps, useRadioGroupContext } from "./radiogroup";
 
 export interface RadiobuttonProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "defaultValue"> {
   children: ReactNode;
   variant?: "plain" | "bounding-box";
+  /**
+   * Set to `true` to add error styling. The component will take care of aria to indicate invalid state.
+   *
+   * Normally you don't need this, as you should wrap your Radiobuttons in the RadioGroup component.
+   * When providing an errorMessage to RadioGroup, all contained Radiobuttons will get correct hasError state.
+   *
+   * You can use this when your Radiobutton is part of a non-HDS fieldset which shows an error message.
+   */
   hasError?: boolean;
   title?: string;
 }
@@ -37,7 +46,9 @@ export const Radiobutton = forwardRef<HTMLInputElement, RadiobuttonProps>(
     ref,
   ) => {
     const { value: selectedValue, hasError: hasErrorContext, ...context } = useRadioGroupContext();
-    const hasError = hasErrorContext || hasErrorProp;
+    const { errorMessage: errorMessageContext } = useFieldsetContext();
+    const hasError = !!errorMessageContext || hasErrorContext || hasErrorProp;
+
     return (
       <div
         className={clsx(

--- a/packages/react/src/form/radiobutton/radiogroup.stories.tsx
+++ b/packages/react/src/form/radiobutton/radiogroup.stories.tsx
@@ -13,9 +13,9 @@ export default meta;
 type Story = StoryObj<typeof RadioGroup>;
 
 export const PlainRadioGroup: Story = {
-  name: "Radio group with radio buttons",
+  name: "Radio group with radiobuttons",
   args: {
-    legend: "Radio group with radio buttons",
+    legend: "Radio group with radiobuttons",
     errorMessage: "",
     name: "group1",
     value: undefined,

--- a/packages/react/src/form/radiobutton/radiogroup.tsx
+++ b/packages/react/src/form/radiobutton/radiogroup.tsx
@@ -15,8 +15,8 @@ export interface RadioGroupProps extends Omit<FieldsetProps, "onChange"> {
   /** If you want the group to be controlled, you can pass the selected value here */
   value?: RadiobuttonProps["value"];
   /**
-   * Error message is passed to the internal Fieldset,
-   * and also marks all radiobuttons as invalid
+   * Error message is passed to the internal Fieldset, and will also give contained Radiobuttons
+   * error styling and aria to indicate invalid state.
    */
   errorMessage?: ReactNode;
   /** Will be passed to all Radiobuttons within the radio group */


### PR DESCRIPTION
Providing an errorMessage to Fieldset will now also give contained Checkboxes or Radiobuttons error styling and aria to indicate invalid state.

For Radiobuttons you are even better off using the already existing RadioGroup.