### PR TITLE
🚧 Grid

### DIFF
--- a/.changeset/new-jobs-watch.md
+++ b/.changeset/new-jobs-watch.md
@@ -1,0 +1,6 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+:sparkles::construction: `Grid` component

--- a/apps/examples/app/examples/layout/grid/center.tsx
+++ b/apps/examples/app/examples/layout/grid/center.tsx
@@ -1,0 +1,25 @@
+import { Grid, Box } from "@postenbring/hedwig-react";
+
+function Example() {
+  return (
+    <Grid gap="12-16" span={{ initial: 4, small: 6 }} center={{ small: true }}>
+      <Box>1</Box>
+      <Box>2</Box>
+      <Box>3</Box>
+      <Box>4</Box>
+      <Box>5</Box>
+      <Box>6</Box>
+    </Grid>
+  );
+}
+
+export default Example;
+
+import type { ExampleConfig } from "../..";
+export const config: ExampleConfig = {
+  breakpointIndicator: "top",
+  description:
+    "Center the grid items horizontally when they are not taking up the full width of the grid.",
+  layout: "centered-fullwidth",
+  index: 1,
+};

--- a/apps/examples/app/examples/layout/grid/demo.tsx
+++ b/apps/examples/app/examples/layout/grid/demo.tsx
@@ -1,0 +1,23 @@
+import { Grid, Box } from "@postenbring/hedwig-react";
+
+function Example() {
+  return (
+    <Grid gap="12-16" span={{ initial: 12, small: 4 }}>
+      <Box>1</Box>
+      <Box>2</Box>
+      <Box>3</Box>
+      <Box>4</Box>
+      <Box>5</Box>
+      <Box>6</Box>
+    </Grid>
+  );
+}
+
+export default Example;
+
+import type { ExampleConfig } from "../..";
+export const config: ExampleConfig = {
+  breakpointIndicator: "top",
+  layout: "centered-fullwidth",
+  index: 0,
+};

--- a/apps/examples/app/examples/layout/grid/eight-four.tsx
+++ b/apps/examples/app/examples/layout/grid/eight-four.tsx
@@ -1,0 +1,27 @@
+import { Grid, Box } from "@postenbring/hedwig-react";
+
+function Example() {
+  return (
+    <Grid gap="12-16" span={{ initial: 12, small: 8 }}>
+      <Box>1</Box>
+      <Grid.Item span={{ small: 4 }}>
+        <Box>2</Box>
+      </Grid.Item>
+      <Grid.Item span={{ small: 4 }}>
+        <Box>3</Box>
+      </Grid.Item>
+      <Box>4</Box>
+    </Grid>
+  );
+}
+
+export default Example;
+
+import type { ExampleConfig } from "../..";
+export const config: ExampleConfig = {
+  breakpointIndicator: "top",
+  description:
+    "A layout where one item is twice as wide as the other. Also called a <code>2/3</code> layout.",
+  layout: "centered-fullwidth",
+  index: 4,
+};

--- a/apps/examples/app/examples/layout/stack/demo.tsx
+++ b/apps/examples/app/examples/layout/stack/demo.tsx
@@ -12,5 +12,5 @@ function Example() {
 
 export default Example;
 
-import type { ExampleConfig } from "..";
+import type { ExampleConfig } from "../..";
 export const config: ExampleConfig = {};

--- a/apps/examples/app/root.module.css
+++ b/apps/examples/app/root.module.css
@@ -30,8 +30,15 @@
 
     font: var(--hds-typography-technical);
     font-size: var(--hds-font-size-technical-max);
-    content: "📱 small";
+    content: "▮ initial";
   }
+
+  @media (min-width: 460px) {
+    &::before {
+      content: "📱 small";
+    }
+  }
+
   @media (min-width: 720px) {
     &::before {
       content: "📺 medium";

--- a/packages/css/src/index.css
+++ b/packages/css/src/index.css
@@ -24,6 +24,7 @@
 @import url("form/textarea/textarea.css");
 @import url("layout/container/container.css");
 @import url("layout/flex/flex.css");
+@import url("layout/grid/grid.css");
 @import url("layout/stack/stack.css");
 @import url("link/link.css");
 @import url("list/list.css");

--- a/packages/css/src/layout/grid/grid.css
+++ b/packages/css/src/layout/grid/grid.css
@@ -1,0 +1,108 @@
+@import url("../../_custom-media.css");
+
+.hds-grid {
+  --hds-grid-gap-initial: initial;
+  --hds-grid-gap-small: var(--hds-grid-gap-initial);
+  --hds-grid-gap-medium: var(--hds-grid-gap-small);
+  --hds-grid-gap-large: var(--hds-grid-gap-medium);
+  --hds-grid-gap-xlarge: var(--hds-grid-gap-large);
+  --hds-grid-gap: var(--hds-grid-gap-initial);
+  --hds-grid-span-initial: 12;
+  --hds-grid-span-small: var(--hds-grid-span-initial);
+  --hds-grid-span-medium: var(--hds-grid-span-small);
+  --hds-grid-span-large: var(--hds-grid-span-medium);
+  --hds-grid-span-xlarge: var(--hds-grid-span-large);
+  --hds-grid-span: var(--hds-grid-span-initial);
+  --hds-grid-center-initial: 0;
+  --hds-grid-center-small: var(--hds-grid-center-initial);
+  --hds-grid-center-medium: var(--hds-grid-center-small);
+  --hds-grid-center-large: var(--hds-grid-center-medium);
+  --hds-grid-center-xlarge: var(--hds-grid-center-large);
+  --hds-grid-center: var(--hds-grid-center-initial);
+
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: var(--hds-grid-gap);
+
+  /**
+   * Set the grid start, allowing for centering by setting a start position relative to the column span
+   * Abuses the fact that `0` is an invalid start value, so we can toggle this behaviour by including `--hds-grid-center` in the calculation.
+   * Assumes a span of 2, 4, 6, 8, or 10 for the centering be correct.
+   */
+  --hds-grid-start: calc(var(--hds-grid-center) * ((12 - var(--hds-grid-span)) / 2 + 1));
+
+  /* Set values for grid items */
+  > * {
+    grid-column: span var(--hds-grid-span) / span var(--hds-grid-span);
+    grid-column-start: var(--hds-grid-start);
+  }
+
+  /* Responsive */
+  @media (--small) {
+    --hds-grid-gap: var(--hds-grid-gap-small);
+    --hds-grid-span: var(--hds-grid-span-small);
+    --hds-grid-center: var(--hds-grid-center-small);
+  }
+
+  @media (--medium) {
+    --hds-grid-gap: var(--hds-grid-gap-medium);
+    --hds-grid-span: var(--hds-grid-span-medium);
+    --hds-grid-center: var(--hds-grid-center-medium);
+  }
+
+  @media (--large) {
+    --hds-grid-gap: var(--hds-grid-gap-large);
+    --hds-grid-span: var(--hds-grid-span-large);
+    --hds-grid-center: var(--hds-grid-center-large);
+  }
+
+  @media (--xlarge) {
+    --hds-grid-gap: var(--hds-grid-gap-xlarge);
+    --hds-grid-span: var(--hds-grid-span-xlarge);
+    --hds-grid-center: var(--hds-grid-center-xlarge);
+  }
+
+  > .hds-grid__item {
+    --hds-grid-item-span-initial: var(--hds-grid-span);
+    --hds-grid-item-span-small: var(--hds-grid-item-span-initial);
+    --hds-grid-item-span-medium: var(--hds-grid-item-span-small);
+    --hds-grid-item-span-large: var(--hds-grid-item-span-medium);
+    --hds-grid-item-span-xlarge: var(--hds-grid-item-span-large);
+    --hds-grid-item-span: var(--hds-grid-item-span-initial);
+    --hds-grid-item-center-initial: var(--hds-grid-center);
+    --hds-grid-item-center-small: var(--hds-grid-item-center-initial);
+    --hds-grid-item-center-medium: var(--hds-grid-item-center-small);
+    --hds-grid-item-center-large: var(--hds-grid-item-center-medium);
+    --hds-grid-item-center-xlarge: var(--hds-grid-item-center-large);
+    --hds-grid-item-center: var(--hds-grid-item-center-initial);
+
+    /* Assumes a span of 2, 4, 6, 8, or 10 */
+    --hds-grid-item-start: calc(
+      var(--hds-grid-item-center) * ((12 - var(--hds-grid-item-span)) / 2 + 1)
+    );
+
+    grid-column: span var(--hds-grid-item-span) / span var(--hds-grid-item-span);
+    grid-column-start: var(--hds-grid-item-start);
+
+    /* Responsive */
+    @media (--small) {
+      --hds-grid-item-span: var(--hds-grid-item-span-small);
+      --hds-grid-item-center: var(--hds-grid-item-center-small);
+    }
+
+    @media (--medium) {
+      --hds-grid-item-span: var(--hds-grid-item-span-medium);
+      --hds-grid-item-center: var(--hds-grid-item-center-medium);
+    }
+
+    @media (--large) {
+      --hds-grid-item-span: var(--hds-grid-item-span-large);
+      --hds-grid-item-center: var(--hds-grid-item-center-large);
+    }
+
+    @media (--xlarge) {
+      --hds-grid-item-span: var(--hds-grid-item-span-xlarge);
+      --hds-grid-item-center: var(--hds-grid-item-center-xlarge);
+    }
+  }
+}

--- a/packages/react/src/layout/grid/grid.tsx
+++ b/packages/react/src/layout/grid/grid.tsx
@@ -1,0 +1,138 @@
+import { clsx } from "@postenbring/hedwig-css/typed-classname";
+import { Slot } from "@radix-ui/react-slot";
+import { forwardRef } from "react";
+import { getResponsiveProps, type ResponsiveProp } from "../responsive";
+import { type SpacingSizes, type ResponsiveSpacingSizes, getSpacingVariable } from "../spacing";
+
+export interface GridProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+
+  /**
+   * Space between grid items. Both horizontal and vertical.
+   *
+   * Use the responsive shorthand `12-16` to jump a level at the `large` breakpoint.
+   *
+   * Or use the responsive object `{ initial: 40, large: 64 }` to set different values at different breakpoints.
+   */
+  gap?: ResponsiveProp<SpacingSizes> | ResponsiveSpacingSizes;
+
+  /**
+   * Column span for the grid items
+   *
+   * `default` is `12`
+   */
+  span?: ResponsiveProp<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12>;
+
+  /**
+   * Center grid items horizontally
+   *
+   * Offsets the start position of the grid items relative to their span so that it appears centered.
+   *
+   * assumes a span of 2, 4, 6, 8, or 10
+   *
+   * a span of `12` is 100% width and centering has no effect
+   *
+   * `default` is `false`
+   */
+  center?: ResponsiveProp<boolean>;
+
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   */
+  asChild?: boolean;
+}
+
+/**
+ * 🚧 A simple opionated abstraction over CSS Grid.
+ *
+ * The grid is always a 12 column grid.
+ *
+ * example
+ * ```tsx
+ * <Grid gap="12-16" span={{ small: 6 }}>
+ *   <div>6/12</div>
+ *   <div>6/12</div>
+ *   <Grid.Item span={{ small: 12 }}>12/12</Grid.Item>
+ *   <div>6/12</div>
+ *   <div>6/12</div>
+ * </Grid>
+ * ```
+ */
+export const Grid = forwardRef<HTMLDivElement, GridProps>(
+  ({ children, asChild, className, span, center, style: _style, gap, ...rest }, ref) => {
+    const Component = asChild ? Slot : "div";
+    const style: React.CSSProperties = {
+      ..._style,
+      ...getResponsiveProps("--hds-grid-gap", gap, getSpacingVariable),
+      ...getResponsiveProps("--hds-grid-span", span),
+      ...getResponsiveProps("--hds-grid-center", center, (value) => (value ? "1" : "0")),
+    };
+    return (
+      <Component
+        style={style}
+        className={clsx("hds-grid", className as undefined)}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+      </Component>
+    );
+  },
+);
+Grid.displayName = "Grid";
+
+export interface GridItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+
+  /**
+   * Column span for the grid item
+   *
+   * `default` is `12`
+   */
+  span?: ResponsiveProp<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12>;
+
+  /**
+   * Center the grid item horizontally
+   *
+   * Offsets the start position of the grid item relative to it's span so that it appears centered.
+   *
+   * assumes a span of 2, 4, 6, 8, or 10
+   *
+   * a span of `12` is 100% width and centering has no effect
+   *
+   * `default` is `false`
+   */
+  center?: ResponsiveProp<boolean>;
+
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   */
+  asChild?: boolean;
+}
+
+/**
+ * 🚧 Grid.Item
+ *
+ * Use as the direct child of a `Grid` to override `span` and `center` for individual items.
+ */
+export const GridItem = forwardRef<HTMLDivElement, GridItemProps>(
+  ({ children, asChild, className, span, center, style: _style, ...rest }, ref) => {
+    const Component = asChild ? Slot : "div";
+    const style: React.CSSProperties = {
+      ..._style,
+      ...getResponsiveProps("--hds-grid-item-span", span),
+      ...getResponsiveProps("--hds-grid-item-center", center, (value) => (value ? "1" : "0")),
+    };
+    return (
+      <Component
+        style={style}
+        className={clsx("hds-grid__item", className as undefined)}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+      </Component>
+    );
+  },
+);
+GridItem.displayName = "Grid.Item";

--- a/packages/react/src/layout/grid/index.tsx
+++ b/packages/react/src/layout/grid/index.tsx
@@ -1,0 +1,11 @@
+import { Grid, GridItem } from "./grid";
+
+const GridComponent = Grid as typeof Grid & {
+  Item: typeof GridItem;
+};
+
+GridComponent.Item = GridItem;
+
+export { GridComponent as Grid, GridItem };
+
+export type * from "./grid";

--- a/packages/react/src/layout/index.tsx
+++ b/packages/react/src/layout/index.tsx
@@ -1,2 +1,3 @@
 export * from "./container/container";
-export * from "./stack/stack";
+export * from "./grid";
+export * from "./stack";


### PR DESCRIPTION
A simple css grid abstraction. Intended usage is for UI compositions where items are to take exactly a known fraction. E.g. half, 1/3, or full. With using the 12 column grid most of these should be possible to make.

The options are configured via css variables that the react component adds to the DOM element, this allows us extensive responsive configuration. 

In addition I added support for centering the items horizontally using some math and css trickery.

| Responsive | Centering |
|--------|--------|
| ![Apr-11-2024 12-36-31](https://github.com/bring/hedwig-design-system/assets/244257/52318302-afbd-4e68-83a5-1d1dc233ed11) | ![Apr-11-2024 12-37-56](https://github.com/bring/hedwig-design-system/assets/244257/9bc005f1-c8b8-48b9-8659-aec91b41901d) | 


## Two columns 2/3 + 1/3
<img width="758" alt="Screenshot 2024-04-11 at 12 35 56" src="https://github.com/bring/hedwig-design-system/assets/244257/ce91bb3b-bb78-4806-9400-572a15601357">



