### PR TITLE
:wrench: use `exports` in css package.json to fix some import issues

### DIFF
--- a/.changeset/orange-buckets-draw.md
+++ b/.changeset/orange-buckets-draw.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-css": patch
+---
+
+:wrench: use `exports` in css package.json to fix some import issues

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -20,7 +20,22 @@
     "typed-classname/**",
     "assets/**"
   ],
-  "main": "./dist/index.css",
+  "exports": {
+    ".": "./dist/index.css",
+    "./dist/*.css": "./dist/*.css",
+    "./typed-classname": {
+      "import": {
+        "types": "./typed-classname/index.d.mts",
+        "default": "./typed-classname/index.mjs"
+      },
+      "require": {
+        "types": "./typed-classname/index.d.ts",
+        "default": "./typed-classname/index.js"
+      }
+    },
+    "./typed-classname/index.js": "./typed-classname/index.js",
+    "./package.json": "./package.json"
+  },
   "license": "MIT",
   "devDependencies": {
     "browserslist": "4.23.0",


### PR DESCRIPTION
Tested the snapshot version with a vite app and a pre-vite remix app. Both works.