### PR TITLE
🏷️  Update type declarations

### DIFF
--- a/.changeset/rare-carpets-live.md
+++ b/.changeset/rare-carpets-live.md
@@ -1,0 +1,8 @@
+---
+"@postenbring/hedwig-react": patch
+---
+
+:label: react: generate types using tsc complete with decleration maps, including `src/` folder
+
+- Faster type generation
+- Makes go to decleration nicer, same as in java/intellij when you get the actual source code

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 nodejs 20.11.1
-pnpm 9.0.6
+pnpm 9.1.0

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       "express": "^4.19.2"
     }
   },
-  "packageManager": "pnpm@9.0.6",
+  "packageManager": "pnpm@9.1.0",
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --cache --fix",
     "packages/css/**/*.{css,scss}": "stylelint --cache --fix",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,17 +9,19 @@
   ],
   "license": "MIT",
   "files": [
-    "dist/**"
+    "dist/**",
+    "src/**"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "pnpm run --sequential /^build:.*/",
+    "build:bundle": "tsup",
+    "build:types": "tsc -p tsconfig.types.json",
     "dev": "tsup --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf .turbo node_modules dist"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "7.43.2",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
     "eslint-config-custom": "workspace:*",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,7 +16,9 @@
     "build": "pnpm run --sequential /^build:.*/",
     "build:bundle": "tsup",
     "build:types": "tsc -p tsconfig.types.json",
-    "dev": "tsup --watch",
+    "dev": "pnpm run --parallel /^dev:.*/",
+    "dev:bundle": "tsup --watch",
+    "dev:types": "tsc -p tsconfig.types.json --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf .turbo node_modules dist"

--- a/packages/react/src/accordion/accordion.tsx
+++ b/packages/react/src/accordion/accordion.tsx
@@ -1,9 +1,11 @@
-import type { HTMLAttributes, ReactElement } from "react";
+import type { ReactElement } from "react";
 import { forwardRef } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
-import type { AccordionItemProps } from "./accordion-item";
+import { AccordionItem, type AccordionItemProps } from "./accordion-item";
+import { AccordionHeader } from "./accordion-header";
+import { AccordionContent } from "./accordion-content";
 
-export interface AccordionProps extends HTMLAttributes<HTMLDivElement> {
+export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Accepts type of <AccordionItem/>
    */
@@ -15,6 +17,27 @@ export interface AccordionProps extends HTMLAttributes<HTMLDivElement> {
   indent?: boolean;
 }
 
+/**
+ * Displays collapsible content sections
+ *
+ * @example
+ * ```tsx
+ * <Accordion>
+ *   <Accordion.Item defaultOpen>
+ *     <Accordion.Header>Item one</Accordion.Header>
+ *     <Accordion.Content>
+ *       Some content
+ *     </Accordion.Content>
+ *   </Accordion.Item>
+ *   <Accordion.Item>
+ *     <Accordion.Header>Item two</Accordion.Header>
+ *     <Accordion.Content>
+ *       Some more content
+ *     </Accordion.Content>
+ *   </Accordion.Item>
+ * </Accordion>
+ * ```
+ */
 export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
   ({ children, className, indent = true, ...rest }, ref) => {
     return (
@@ -31,6 +54,15 @@ export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
       </div>
     );
   },
-);
-
+) as AccordionType;
 Accordion.displayName = "Accordion";
+
+Accordion.Item = AccordionItem;
+Accordion.Header = AccordionHeader;
+Accordion.Content = AccordionContent;
+
+type AccordionType = ReturnType<typeof forwardRef<HTMLDivElement, AccordionProps>> & {
+  Item: typeof AccordionItem;
+  Header: typeof AccordionHeader;
+  Content: typeof AccordionContent;
+};

--- a/packages/react/src/accordion/index.tsx
+++ b/packages/react/src/accordion/index.tsx
@@ -1,19 +1,7 @@
-import { Accordion } from "./accordion";
-import { AccordionItem } from "./accordion-item";
-import { AccordionHeader } from "./accordion-header";
-import { AccordionContent } from "./accordion-content";
-
-const AccordionComponent = Accordion as typeof Accordion & {
-  Item: typeof AccordionItem;
-  Header: typeof AccordionHeader;
-  Content: typeof AccordionContent;
-};
-
-AccordionComponent.Item = AccordionItem;
-AccordionComponent.Header = AccordionHeader;
-AccordionComponent.Content = AccordionContent;
-
-export { AccordionComponent as Accordion, AccordionItem, AccordionHeader, AccordionContent };
+export { Accordion } from "./accordion";
+export { AccordionItem } from "./accordion-item";
+export { AccordionHeader } from "./accordion-header";
+export { AccordionContent } from "./accordion-content";
 
 export type * from "./accordion";
 export type * from "./accordion-item";

--- a/packages/react/src/box/box.tsx
+++ b/packages/react/src/box/box.tsx
@@ -2,6 +2,21 @@ import { forwardRef, useCallback, useState } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
 import { Slot, Slottable } from "@radix-ui/react-slot";
 
+export type BoxCloseButtonProps = Omit<React.HTMLAttributes<HTMLButtonElement>, "children">;
+export const BoxCloseButton = forwardRef<HTMLButtonElement, BoxCloseButtonProps>(
+  ({ className, ...rest }, ref) => {
+    return (
+      <button
+        className={clsx("hds-box__close-button", className as undefined)}
+        ref={ref}
+        type="button"
+        {...rest}
+      />
+    );
+  },
+);
+BoxCloseButton.displayName = "Box.CloseButton";
+
 export interface BoxProps extends React.HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
 
@@ -97,20 +112,11 @@ export const Box = forwardRef<HTMLDivElement, BoxProps>(
       </Component>
     );
   },
-);
+) as BoxType;
 Box.displayName = "Box";
 
-export type BoxCloseButtonProps = Omit<React.HTMLAttributes<HTMLButtonElement>, "children">;
-export const BoxCloseButton = forwardRef<HTMLButtonElement, BoxCloseButtonProps>(
-  ({ className, ...rest }, ref) => {
-    return (
-      <button
-        className={clsx("hds-box__close-button", className as undefined)}
-        ref={ref}
-        type="button"
-        {...rest}
-      />
-    );
-  },
-);
-BoxCloseButton.displayName = "Box.CloseButton";
+Box.CloseButton = BoxCloseButton;
+
+type BoxType = ReturnType<typeof forwardRef<HTMLDivElement, BoxProps>> & {
+  CloseButton: typeof BoxCloseButton;
+};

--- a/packages/react/src/box/index.tsx
+++ b/packages/react/src/box/index.tsx
@@ -1,10 +1,3 @@
-import { Box, BoxCloseButton } from "./box";
-
-const BoxComponent = Box as typeof Box & {
-  CloseButton: typeof BoxCloseButton;
-};
-BoxComponent.CloseButton = BoxCloseButton;
-
-export { BoxComponent as Box, BoxCloseButton };
+export { Box, BoxCloseButton } from "./box";
 
 export type * from "./box";

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -3,39 +3,6 @@ import { forwardRef } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
 import { Slot } from "@radix-ui/react-slot";
 
-export interface CardBaseProps extends React.HTMLAttributes<HTMLDivElement> {
-  children: ReactNode;
-
-  /**
-   * Change the default rendered element for the one passed as a child, merging their props and behavior.
-   *
-   * @default false
-   */
-  asChild?: boolean;
-}
-
-export const Card = forwardRef<
-  HTMLDivElement,
-  CardBaseProps & {
-    /**
-     * A Card should in most cases appear as a big link,
-     * but the actual link should just be the header title.
-     * To make life better for those with screen readers we should not make
-     * the entire card a link, as that would cause the entire card to be read
-     * as a link to the user. That would be perceived as information overload.
-     */
-    as?: "section" | "div" | "article" | "aside";
-  }
->(({ as: Tag = "section", asChild, className, children, ...rest }, ref) => {
-  const Component = asChild ? Slot : Tag;
-  return (
-    <Component {...rest} className={clsx("hds-card", className as undefined)} ref={ref}>
-      {children}
-    </Component>
-  );
-});
-Card.displayName = "Card";
-
 export const CardMedia = forwardRef<HTMLDivElement, CardBaseProps>(
   ({ asChild, className, children, ...rest }, ref) => {
     const Component = asChild ? Slot : "div";
@@ -197,3 +164,59 @@ export const CardBodyActionArrow = forwardRef<HTMLSpanElement, CardBodyActionArr
   },
 );
 CardBodyActionArrow.displayName = "Card.BodyActionArrow";
+
+export interface CardBaseProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   *
+   * @default false
+   */
+  asChild?: boolean;
+}
+
+export interface CardProps extends CardBaseProps {
+  /**
+   * A Card should in most cases appear as a big link,
+   * but the actual link should just be the header title.
+   * To make life better for those with screen readers we should not make
+   * the entire card a link, as that would cause the entire card to be read
+   * as a link to the user. That would be perceived as information overload.
+   */
+  as?: "section" | "div" | "article" | "aside";
+}
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(
+  ({ as: Tag = "section", asChild, className, children, ...rest }, ref) => {
+    const Component = asChild ? Slot : Tag;
+    return (
+      <Component {...rest} className={clsx("hds-card", className as undefined)} ref={ref}>
+        {children}
+      </Component>
+    );
+  },
+) as CardType;
+Card.displayName = "Card";
+
+Card.Media = CardMedia;
+Card.MediaImg = CardMediaImg;
+Card.Body = CardBody;
+Card.BodyHeader = CardBodyHeader;
+Card.BodyHeaderOverline = CardBodyHeaderOverline;
+Card.BodyHeaderTitle = CardBodyHeaderTitle;
+Card.BodyDescription = CardBodyDescription;
+Card.BodyAction = CardBodyAction;
+Card.BodyActionArrow = CardBodyActionArrow;
+
+type CardType = ReturnType<typeof forwardRef<HTMLDivElement, CardProps>> & {
+  Media: typeof CardMedia;
+  MediaImg: typeof CardMediaImg;
+  Body: typeof CardBody;
+  BodyHeader: typeof CardBodyHeader;
+  BodyHeaderOverline: typeof CardBodyHeaderOverline;
+  BodyHeaderTitle: typeof CardBodyHeaderTitle;
+  BodyDescription: typeof CardBodyDescription;
+  BodyAction: typeof CardBodyAction;
+  BodyActionArrow: typeof CardBodyActionArrow;
+};

--- a/packages/react/src/card/index.tsx
+++ b/packages/react/src/card/index.tsx
@@ -1,4 +1,4 @@
-import {
+export {
   Card,
   CardMedia,
   CardMediaImg,
@@ -10,39 +10,5 @@ import {
   CardBodyAction,
   CardBodyActionArrow,
 } from "./card";
-
-const CardComponent = Card as typeof Card & {
-  Media: typeof CardMedia;
-  MediaImg: typeof CardMediaImg;
-  Body: typeof CardBody;
-  BodyHeader: typeof CardBodyHeader;
-  BodyHeaderOverline: typeof CardBodyHeaderOverline;
-  BodyHeaderTitle: typeof CardBodyHeaderTitle;
-  BodyDescription: typeof CardBodyDescription;
-  BodyAction: typeof CardBodyAction;
-  BodyActionArrow: typeof CardBodyActionArrow;
-};
-CardComponent.Media = CardMedia;
-CardComponent.MediaImg = CardMediaImg;
-CardComponent.Body = CardBody;
-CardComponent.BodyHeader = CardBodyHeader;
-CardComponent.BodyHeaderOverline = CardBodyHeaderOverline;
-CardComponent.BodyHeaderTitle = CardBodyHeaderTitle;
-CardComponent.BodyDescription = CardBodyDescription;
-CardComponent.BodyAction = CardBodyAction;
-CardComponent.BodyActionArrow = CardBodyActionArrow;
-
-export {
-  CardComponent as Card,
-  CardMedia,
-  CardMediaImg,
-  CardBody,
-  CardBodyHeader,
-  CardBodyHeaderOverline,
-  CardBodyHeaderTitle,
-  CardBodyDescription,
-  CardBodyAction,
-  CardBodyActionArrow,
-};
 
 export type * from "./card";

--- a/packages/react/src/footer/footer.tsx
+++ b/packages/react/src/footer/footer.tsx
@@ -5,45 +5,6 @@ import { Accordion } from "../accordion";
 import { LinkList } from "../list/link-list";
 import { PrimaryButton } from "../button";
 
-export interface FooterProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * Footer variant
-   *
-   * @default "default"
-   */
-  variant?: "default" | "slim";
-
-  /**
-   * Change the default rendered element for the one passed as a child, merging their props and behavior.
-   *
-   * @default false
-   */
-  asChild?: boolean;
-}
-
-/**
- * 🚨 WORK IN PROGRESS 🚨
- */
-export const Footer = forwardRef<HTMLDivElement, FooterProps>(
-  ({ children, className, variant, asChild, ...rest }, ref) => {
-    const Component = asChild ? Slot : "footer";
-    return (
-      <Component
-        className={clsx(
-          `hds-footer`,
-          variant === "slim" && "hds-footer--slim",
-          className as undefined,
-        )}
-        ref={ref}
-        {...rest}
-      >
-        {children}
-      </Component>
-    );
-  },
-);
-Footer.displayName = "Footer";
-
 interface FooterLogoProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Change the default rendered element for the one passed as a child, merging their props and behavior.
@@ -155,3 +116,54 @@ export const FooterLinkSection = forwardRef<HTMLDivElement, FooterLinkSectionPro
   },
 );
 FooterLinkSection.displayName = "Footer.LinkSection";
+
+export interface FooterProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Footer variant
+   *
+   * @default "default"
+   */
+  variant?: "default" | "slim";
+
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   *
+   * @default false
+   */
+  asChild?: boolean;
+}
+
+/**
+ * 🚨 WORK IN PROGRESS 🚨
+ */
+export const Footer = forwardRef<HTMLDivElement, FooterProps>(
+  ({ children, className, variant, asChild, ...rest }, ref) => {
+    const Component = asChild ? Slot : "footer";
+    return (
+      <Component
+        className={clsx(
+          `hds-footer`,
+          variant === "slim" && "hds-footer--slim",
+          className as undefined,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+      </Component>
+    );
+  },
+) as FooterType;
+Footer.displayName = "Footer";
+
+type FooterType = ReturnType<typeof forwardRef<HTMLDivElement, FooterProps>> & {
+  Logo: typeof FooterLogo;
+  ButtonLink: typeof FooterButtonLink;
+  LinkSections: typeof FooterLinkSections;
+  LinkSection: typeof FooterLinkSection;
+};
+
+Footer.Logo = FooterLogo;
+Footer.ButtonLink = FooterButtonLink;
+Footer.LinkSections = FooterLinkSections;
+Footer.LinkSection = FooterLinkSection;

--- a/packages/react/src/footer/index.tsx
+++ b/packages/react/src/footer/index.tsx
@@ -1,4 +1,4 @@
-import {
+export {
   Footer,
   FooterLogo,
   FooterButtonLink,
@@ -6,22 +6,4 @@ import {
   FooterLinkSection,
 } from "./footer";
 
-const FooterComponent = Footer as typeof Footer & {
-  Logo: typeof FooterLogo;
-  ButtonLink: typeof FooterButtonLink;
-  LinkSections: typeof FooterLinkSections;
-  LinkSection: typeof FooterLinkSection;
-};
-FooterComponent.Logo = FooterLogo;
-FooterComponent.ButtonLink = FooterButtonLink;
-FooterComponent.LinkSections = FooterLinkSections;
-FooterComponent.LinkSection = FooterLinkSection;
-
-export {
-  FooterComponent as Footer,
-  FooterLogo,
-  FooterButtonLink,
-  FooterLinkSections,
-  FooterLinkSection,
-};
 export type * from "./footer";

--- a/packages/react/src/layout/grid/grid.tsx
+++ b/packages/react/src/layout/grid/grid.tsx
@@ -4,6 +4,62 @@ import { forwardRef } from "react";
 import { getResponsiveProps, type ResponsiveProp } from "../responsive";
 import { type SpacingSizes, type ResponsiveSpacingSizes, getSpacingVariable } from "../spacing";
 
+export interface GridItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+
+  /**
+   * Column span for the grid item
+   *
+   * `default` is `12`
+   */
+  span?: ResponsiveProp<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12>;
+
+  /**
+   * Center the grid item horizontally
+   *
+   * Offsets the start position of the grid item relative to it's span so that it appears centered.
+   *
+   * assumes a span of 2, 4, 6, 8, or 10
+   *
+   * a span of `12` is 100% width and centering has no effect
+   *
+   * `default` is `false`
+   */
+  center?: ResponsiveProp<boolean>;
+
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   */
+  asChild?: boolean;
+}
+
+/**
+ * 🚧 Grid.Item
+ *
+ * Use as the direct child of a `Grid` to override `span` and `center` for individual items.
+ */
+export const GridItem = forwardRef<HTMLDivElement, GridItemProps>(
+  ({ children, asChild, className, span, center, style: _style, ...rest }, ref) => {
+    const Component = asChild ? Slot : "div";
+    const style: React.CSSProperties = {
+      ..._style,
+      ...getResponsiveProps("--hds-grid-item-span", span),
+      ...getResponsiveProps("--hds-grid-item-center", center, (value) => (value ? "1" : "0")),
+    };
+    return (
+      <Component
+        style={style}
+        className={clsx("hds-grid__item", className as undefined)}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+      </Component>
+    );
+  },
+);
+GridItem.displayName = "Grid.Item";
+
 export interface GridProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
 
@@ -97,61 +153,11 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
       </Component>
     );
   },
-);
+) as GridType;
 Grid.displayName = "Grid";
 
-export interface GridItemProps extends React.HTMLAttributes<HTMLDivElement> {
-  children: React.ReactNode;
+type GridType = ReturnType<typeof forwardRef<HTMLDivElement, GridProps>> & {
+  Item: typeof GridItem;
+};
 
-  /**
-   * Column span for the grid item
-   *
-   * `default` is `12`
-   */
-  span?: ResponsiveProp<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12>;
-
-  /**
-   * Center the grid item horizontally
-   *
-   * Offsets the start position of the grid item relative to it's span so that it appears centered.
-   *
-   * assumes a span of 2, 4, 6, 8, or 10
-   *
-   * a span of `12` is 100% width and centering has no effect
-   *
-   * `default` is `false`
-   */
-  center?: ResponsiveProp<boolean>;
-
-  /**
-   * Change the default rendered element for the one passed as a child, merging their props and behavior.
-   */
-  asChild?: boolean;
-}
-
-/**
- * 🚧 Grid.Item
- *
- * Use as the direct child of a `Grid` to override `span` and `center` for individual items.
- */
-export const GridItem = forwardRef<HTMLDivElement, GridItemProps>(
-  ({ children, asChild, className, span, center, style: _style, ...rest }, ref) => {
-    const Component = asChild ? Slot : "div";
-    const style: React.CSSProperties = {
-      ..._style,
-      ...getResponsiveProps("--hds-grid-item-span", span),
-      ...getResponsiveProps("--hds-grid-item-center", center, (value) => (value ? "1" : "0")),
-    };
-    return (
-      <Component
-        style={style}
-        className={clsx("hds-grid__item", className as undefined)}
-        ref={ref}
-        {...rest}
-      >
-        {children}
-      </Component>
-    );
-  },
-);
-GridItem.displayName = "Grid.Item";
+Grid.Item = GridItem;

--- a/packages/react/src/layout/grid/index.tsx
+++ b/packages/react/src/layout/grid/index.tsx
@@ -1,11 +1,3 @@
-import { Grid, GridItem } from "./grid";
-
-const GridComponent = Grid as typeof Grid & {
-  Item: typeof GridItem;
-};
-
-GridComponent.Item = GridItem;
-
-export { GridComponent as Grid, GridItem };
+export { Grid, GridItem } from "./grid";
 
 export type * from "./grid";

--- a/packages/react/src/message/index.tsx
+++ b/packages/react/src/message/index.tsx
@@ -1,11 +1,2 @@
-import { Message, MessageTitle, MessageDescription } from "./message";
-
-const MessageComponent = Message as typeof Message & {
-  Title: typeof MessageTitle;
-  Description: typeof MessageDescription;
-};
-
-MessageComponent.Title = MessageTitle;
-MessageComponent.Description = MessageDescription;
-
-export { MessageComponent as Message, MessageTitle, MessageDescription };
+export { Message, MessageTitle, MessageDescription } from "./message";
+export type * from "./message";

--- a/packages/react/src/message/message.tsx
+++ b/packages/react/src/message/message.tsx
@@ -3,40 +3,6 @@ import { clsx } from "@postenbring/hedwig-css/typed-classname";
 import { Slot } from "@radix-ui/react-slot";
 import { Box, type BoxProps } from "../box/box";
 
-export type MessageProps = (
-  | {
-      variant?: "success" | "attention" | "warning";
-      icon?: never;
-      iconClassName?: never;
-    }
-  | {
-      variant: "neutral";
-      icon?: React.ReactNode;
-      iconClassName?: string;
-    }
-) &
-  Omit<BoxProps, "variant" | "asChild">;
-
-export const Message = forwardRef<HTMLDivElement, MessageProps>(
-  ({ children, className, variant = "success", icon, iconClassName, ...rest }, ref) => {
-    return (
-      <Box
-        className={clsx(`hds-message`, `hds-message--${variant}`, className as undefined)}
-        ref={ref}
-        {...rest}
-      >
-        {variant === "neutral" && (
-          <div className={clsx("hds-message--neutral__icon", iconClassName as undefined)}>
-            {icon}
-          </div>
-        )}
-        {children}
-      </Box>
-    );
-  },
-);
-Message.displayName = "Message";
-
 interface MessageTitleProps extends React.HTMLAttributes<HTMLParagraphElement> {
   /**
    * Change the default rendered element for the one passed as a child, merging their props and behavior.
@@ -80,3 +46,44 @@ export const MessageDescription = forwardRef<HTMLParagraphElement, MessageDescri
   },
 );
 MessageDescription.displayName = "Message.Description";
+
+export type MessageProps = (
+  | {
+      variant?: "success" | "attention" | "warning";
+      icon?: never;
+      iconClassName?: never;
+    }
+  | {
+      variant: "neutral";
+      icon?: React.ReactNode;
+      iconClassName?: string;
+    }
+) &
+  Omit<BoxProps, "variant" | "asChild">;
+
+export const Message = forwardRef<HTMLDivElement, MessageProps>(
+  ({ children, className, variant = "success", icon, iconClassName, ...rest }, ref) => {
+    return (
+      <Box
+        className={clsx(`hds-message`, `hds-message--${variant}`, className as undefined)}
+        ref={ref}
+        {...rest}
+      >
+        {variant === "neutral" && (
+          <div className={clsx("hds-message--neutral__icon", iconClassName as undefined)}>
+            {icon}
+          </div>
+        )}
+        {children}
+      </Box>
+    );
+  },
+) as MessageType;
+Message.displayName = "Message";
+
+type MessageType = ReturnType<typeof forwardRef<HTMLDivElement, MessageProps>> & {
+  Title: typeof MessageTitle;
+  Description: typeof MessageDescription;
+};
+Message.Title = MessageTitle;
+Message.Description = MessageDescription;

--- a/packages/react/src/modal/index.tsx
+++ b/packages/react/src/modal/index.tsx
@@ -1,13 +1,3 @@
-import { Modal, ModalHeader, ModalContent, ModalFooter } from "./modal";
+export { Modal, ModalHeader, ModalContent, ModalFooter } from "./modal";
 
-const ModalComponent = Modal as typeof Modal & {
-  Header: typeof ModalHeader;
-  Content: typeof ModalContent;
-  Footer: typeof ModalFooter;
-};
-ModalComponent.Header = ModalHeader;
-ModalComponent.Content = ModalContent;
-ModalComponent.Footer = ModalFooter;
-
-export { ModalComponent as Modal, ModalHeader, ModalContent, ModalFooter };
 export type * from "./modal";

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -4,6 +4,72 @@ import { Slot } from "@radix-ui/react-slot";
 import { Box } from "../box/box";
 import { useMergeRefs } from "../utils";
 
+interface ModalHeaderProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   *
+   * @default false
+   */
+  asChild?: boolean;
+}
+export const ModalHeader = forwardRef<HTMLHeadingElement, ModalHeaderProps>(
+  ({ asChild, className, ...rest }, ref) => {
+    const Component = asChild ? Slot : "h1";
+    return (
+      <Component
+        className={clsx("hds-modal__header", className as undefined)}
+        ref={ref}
+        {...rest}
+      />
+    );
+  },
+);
+ModalHeader.displayName = "Modal.Header";
+
+interface ModalContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   *
+   * @default false
+   */
+  asChild?: boolean;
+}
+export const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(
+  ({ asChild, className, ...rest }, ref) => {
+    const Component = asChild ? Slot : "div";
+    return (
+      <Component
+        className={clsx("hds-modal__content", className as undefined)}
+        ref={ref}
+        {...rest}
+      />
+    );
+  },
+);
+ModalContent.displayName = "Modal.Content";
+
+interface ModalFooterProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   *
+   * @default false
+   */
+  asChild?: boolean;
+}
+export const ModalFooter = forwardRef<HTMLDivElement, ModalFooterProps>(
+  ({ asChild, className, ...rest }, ref) => {
+    const Component = asChild ? Slot : "footer";
+    return (
+      <Component
+        className={clsx("hds-modal__footer", className as undefined)}
+        ref={ref}
+        {...rest}
+      />
+    );
+  },
+);
+ModalFooter.displayName = "Modal.Footer";
+
 export interface ModalProps extends React.HTMLAttributes<HTMLDialogElement> {
   children: React.ReactNode;
 
@@ -99,74 +165,18 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
       </Box>
     );
   },
-);
+) as ModalType;
 Modal.displayName = "Modal";
 
-interface ModalHeaderProps extends React.HTMLAttributes<HTMLHeadingElement> {
-  /**
-   * Change the default rendered element for the one passed as a child, merging their props and behavior.
-   *
-   * @default false
-   */
-  asChild?: boolean;
-}
-export const ModalHeader = forwardRef<HTMLHeadingElement, ModalHeaderProps>(
-  ({ asChild, className, ...rest }, ref) => {
-    const Component = asChild ? Slot : "h1";
-    return (
-      <Component
-        className={clsx("hds-modal__header", className as undefined)}
-        ref={ref}
-        {...rest}
-      />
-    );
-  },
-);
-ModalHeader.displayName = "Modal.Header";
+type ModalType = ReturnType<typeof forwardRef<HTMLDialogElement, ModalProps>> & {
+  Header: typeof ModalHeader;
+  Content: typeof ModalContent;
+  Footer: typeof ModalFooter;
+};
 
-interface ModalContentProps extends React.HTMLAttributes<HTMLDivElement> {
-  /**
-   * Change the default rendered element for the one passed as a child, merging their props and behavior.
-   *
-   * @default false
-   */
-  asChild?: boolean;
-}
-export const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(
-  ({ asChild, className, ...rest }, ref) => {
-    const Component = asChild ? Slot : "div";
-    return (
-      <Component
-        className={clsx("hds-modal__content", className as undefined)}
-        ref={ref}
-        {...rest}
-      />
-    );
-  },
-);
-ModalContent.displayName = "Modal.Content";
-
-interface ModalFooterProps extends React.HTMLAttributes<HTMLDivElement> {
-  /**
-   * Change the default rendered element for the one passed as a child, merging their props and behavior.
-   *
-   * @default false
-   */
-  asChild?: boolean;
-}
-export const ModalFooter = forwardRef<HTMLDivElement, ModalFooterProps>(
-  ({ asChild, className, ...rest }, ref) => {
-    const Component = asChild ? Slot : "footer";
-    return (
-      <Component
-        className={clsx("hds-modal__footer", className as undefined)}
-        ref={ref}
-        {...rest}
-      />
-    );
-  },
-);
-ModalFooter.displayName = "Modal.Footer";
+Modal.Header = ModalHeader;
+Modal.Content = ModalContent;
+Modal.Footer = ModalFooter;
 
 function useScrollLock(modalRef: React.RefObject<HTMLDialogElement>, bodyClass: string) {
   useEffect(() => {

--- a/packages/react/src/navbar/index.tsx
+++ b/packages/react/src/navbar/index.tsx
@@ -1,4 +1,4 @@
-import {
+export {
   Navbar,
   NavbarLogo,
   NavbarItem,
@@ -8,48 +8,11 @@ import {
   NavbarNavigation,
   NavbarLogoAndServiceText,
 } from "./navbar";
-import {
+export {
   useNavbarExpendableMenuContext,
   NavbarExpandableMenu,
   NavbarExpandableMenuTrigger,
   NavbarExpandableMenuContent,
 } from "./navbar-expandable-menu";
 
-const NavbarComponent = Navbar as typeof Navbar & {
-  Logo: typeof NavbarLogo;
-  LogoAndServiceText: typeof NavbarLogoAndServiceText;
-  ExpandableMenu: typeof NavbarExpandableMenu;
-  ExpandableMenuTrigger: typeof NavbarExpandableMenuTrigger;
-  ExpandableMenuContent: typeof NavbarExpandableMenuContent;
-  Item: typeof NavbarItem;
-  ButtonItem: typeof NavbarButtonItem;
-  LinkItem: typeof NavbarLinkItem;
-  ItemIcon: typeof NavbarItemIcon;
-  Navigation: typeof NavbarNavigation;
-};
-NavbarComponent.Logo = NavbarLogo;
-NavbarComponent.LogoAndServiceText = NavbarLogoAndServiceText;
-NavbarComponent.ExpandableMenu = NavbarExpandableMenu;
-NavbarComponent.ExpandableMenuTrigger = NavbarExpandableMenuTrigger;
-NavbarComponent.ExpandableMenuContent = NavbarExpandableMenuContent;
-NavbarComponent.Item = NavbarItem;
-NavbarComponent.ButtonItem = NavbarButtonItem;
-NavbarComponent.LinkItem = NavbarLinkItem;
-NavbarComponent.ItemIcon = NavbarItemIcon;
-NavbarComponent.Navigation = NavbarNavigation;
-
-export {
-  NavbarComponent as Navbar,
-  NavbarLogo,
-  NavbarItem,
-  NavbarButtonItem,
-  NavbarLinkItem,
-  NavbarItemIcon,
-  NavbarNavigation,
-  NavbarLogoAndServiceText,
-  useNavbarExpendableMenuContext,
-  NavbarExpandableMenu,
-  NavbarExpandableMenuTrigger,
-  NavbarExpandableMenuContent,
-};
 export type * from "./navbar";

--- a/packages/react/src/navbar/navbar.tsx
+++ b/packages/react/src/navbar/navbar.tsx
@@ -1,45 +1,11 @@
 import { forwardRef, type HTMLAttributes } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
 import { Slot } from "@radix-ui/react-slot";
-
-export interface NavbarProps extends HTMLAttributes<HTMLElement> {
-  /**
-   * Navbar variant
-   *
-   * By default the `posten.no` variant is used which has a fixed logo and a fixed height of 112px
-   *
-   * For internal services or flagship services use the `service` should be used
-   *
-   * @default "default"
-   */
-  variant?: "default" | "service";
-
-  /**
-   * Change the default rendered element for the one passed as a child, merging their props and behavior.
-   *
-   * @default false
-   */
-  asChild?: boolean;
-}
-
-/**
- * 🚨 WORK IN PROGRESS 🚨
- */
-export const Navbar = forwardRef<HTMLElement, NavbarProps>(
-  ({ asChild, children, className, variant, ...rest }, ref) => {
-    const Component = asChild ? Slot : "header";
-    return (
-      <Component
-        className={clsx("hds-navbar", variant && `hds-navbar--${variant}`, className as undefined)}
-        ref={ref}
-        {...rest}
-      >
-        {children}
-      </Component>
-    );
-  },
-);
-Navbar.displayName = "Navbar";
+import {
+  NavbarExpandableMenu,
+  NavbarExpandableMenuContent,
+  NavbarExpandableMenuTrigger,
+} from "./navbar-expandable-menu";
 
 interface NavbarLogoProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -233,3 +199,66 @@ export const NavbarNavigation = forwardRef<HTMLDivElement, NavbarNavigationProps
   },
 );
 NavbarNavigation.displayName = "Navbar.Navigation";
+
+export interface NavbarProps extends HTMLAttributes<HTMLElement> {
+  /**
+   * Navbar variant
+   *
+   * By default the `posten.no` variant is used which has a fixed logo and a fixed height of 112px
+   *
+   * For internal services or flagship services use the `service` should be used
+   *
+   * @default "default"
+   */
+  variant?: "default" | "service";
+
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   *
+   * @default false
+   */
+  asChild?: boolean;
+}
+
+/**
+ * 🚨 WORK IN PROGRESS 🚨
+ */
+export const Navbar = forwardRef<HTMLDivElement, NavbarProps>(
+  ({ asChild, children, className, variant, ...rest }, ref) => {
+    const Component = asChild ? Slot : "header";
+    return (
+      <Component
+        className={clsx("hds-navbar", variant && `hds-navbar--${variant}`, className as undefined)}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+      </Component>
+    );
+  },
+) as NavbarType;
+Navbar.displayName = "Navbar";
+
+type NavbarType = ReturnType<typeof forwardRef<HTMLDivElement, NavbarProps>> & {
+  Logo: typeof NavbarLogo;
+  LogoAndServiceText: typeof NavbarLogoAndServiceText;
+  ExpandableMenu: typeof NavbarExpandableMenu;
+  ExpandableMenuTrigger: typeof NavbarExpandableMenuTrigger;
+  ExpandableMenuContent: typeof NavbarExpandableMenuContent;
+  Item: typeof NavbarItem;
+  ButtonItem: typeof NavbarButtonItem;
+  LinkItem: typeof NavbarLinkItem;
+  ItemIcon: typeof NavbarItemIcon;
+  Navigation: typeof NavbarNavigation;
+};
+
+Navbar.Logo = NavbarLogo;
+Navbar.LogoAndServiceText = NavbarLogoAndServiceText;
+Navbar.ExpandableMenu = NavbarExpandableMenu;
+Navbar.ExpandableMenuTrigger = NavbarExpandableMenuTrigger;
+Navbar.ExpandableMenuContent = NavbarExpandableMenuContent;
+Navbar.Item = NavbarItem;
+Navbar.ButtonItem = NavbarButtonItem;
+Navbar.LinkItem = NavbarLinkItem;
+Navbar.ItemIcon = NavbarItemIcon;
+Navbar.Navigation = NavbarNavigation;

--- a/packages/react/src/tabs/index.tsx
+++ b/packages/react/src/tabs/index.tsx
@@ -1,19 +1,6 @@
-import { Tabs } from "./tabs";
-import { TabsList, TabsTab } from "./tabs-list";
-import { TabsContents, TabsContent } from "./tabs-content";
-
-const TabsComponent = Tabs as typeof Tabs & {
-  List: typeof TabsList;
-  Tab: typeof TabsTab;
-  Contents: typeof TabsContents;
-  Content: typeof TabsContent;
-};
-TabsComponent.List = TabsList;
-TabsComponent.Tab = TabsTab;
-TabsComponent.Contents = TabsContents;
-TabsComponent.Content = TabsContent;
-
-export { TabsComponent as Tabs, TabsList, TabsTab, TabsContents, TabsContent };
+export { Tabs } from "./tabs";
+export { TabsList, TabsTab } from "./tabs-list";
+export { TabsContents, TabsContent } from "./tabs-content";
 
 export type * from "./tabs";
 export type * from "./tabs-list";

--- a/packages/react/src/tabs/tabs.tsx
+++ b/packages/react/src/tabs/tabs.tsx
@@ -3,8 +3,8 @@ import { forwardRef, useState } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
 import { Slot } from "@radix-ui/react-slot";
 import { TabsContext } from "./context";
-import type { TabsContentsProps } from "./tabs-content";
-import type { TabsListProps } from "./tabs-list";
+import { TabsContent, TabsContents, type TabsContentsProps } from "./tabs-content";
+import { TabsList, TabsTab, type TabsListProps } from "./tabs-list";
 
 export interface TabsProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactElement<TabsListProps | TabsContentsProps>[] | ReactElement;
@@ -34,5 +34,17 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
       </Component>
     );
   },
-);
+) as TabsType;
 Tabs.displayName = "Tabs";
+
+type TabsType = ReturnType<typeof forwardRef<HTMLDivElement, TabsProps>> & {
+  List: typeof TabsList;
+  Tab: typeof TabsTab;
+  Contents: typeof TabsContents;
+  Content: typeof TabsContent;
+};
+
+Tabs.List = TabsList;
+Tabs.Tab = TabsTab;
+Tabs.Contents = TabsContents;
+Tabs.Content = TabsContent;

--- a/packages/react/tsconfig.types.json
+++ b/packages/react/tsconfig.types.json
@@ -1,0 +1,12 @@
+{
+  "extends": "hedwig-tsconfig/react-library.json",
+  "include": ["src/"],
+  "exclude": ["src/**/*.stories.ts", "src/**/*.stories.tsx"],
+  "compilerOptions": {
+    "verbatimModuleSyntax": true,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   sourcemap: true,
   bundle: true,
   format: ["esm", "cjs"],
-  experimentalDts: true,
+  dts: false,
   external: ["react", "react-dom"],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,9 +263,6 @@ importers:
         specifier: 1.0.2
         version: 1.0.2(@types/react@18.3.1)(react@18.3.1)
     devDependencies:
-      '@microsoft/api-extractor':
-        specifier: 7.43.2
-        version: 7.43.2(@types/node@20.12.10)
       '@types/react':
         specifier: ^18.3.1
         version: 18.3.1
@@ -1150,7 +1147,7 @@ packages:
       react: '>=16.8.0'
 
   '@esbuild/aix-ppc64@0.19.12':
-    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
+    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==, tarball: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [aix]
@@ -1168,7 +1165,7 @@ packages:
     os: [android]
 
   '@esbuild/android-arm64@0.19.12':
-    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
+    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==, tarball: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -1186,7 +1183,7 @@ packages:
     os: [android]
 
   '@esbuild/android-arm@0.19.12':
-    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
+    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==, tarball: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -1204,7 +1201,7 @@ packages:
     os: [android]
 
   '@esbuild/android-x64@0.19.12':
-    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
+    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==, tarball: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -1222,7 +1219,7 @@ packages:
     os: [darwin]
 
   '@esbuild/darwin-arm64@0.19.12':
-    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
+    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==, tarball: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -1240,7 +1237,7 @@ packages:
     os: [darwin]
 
   '@esbuild/darwin-x64@0.19.12':
-    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
+    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==, tarball: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -1258,7 +1255,7 @@ packages:
     os: [freebsd]
 
   '@esbuild/freebsd-arm64@0.19.12':
-    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
+    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==, tarball: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -1276,7 +1273,7 @@ packages:
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.19.12':
-    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
+    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==, tarball: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -1294,7 +1291,7 @@ packages:
     os: [linux]
 
   '@esbuild/linux-arm64@0.19.12':
-    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
+    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==, tarball: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -1312,7 +1309,7 @@ packages:
     os: [linux]
 
   '@esbuild/linux-arm@0.19.12':
-    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
+    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==, tarball: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -1330,7 +1327,7 @@ packages:
     os: [linux]
 
   '@esbuild/linux-ia32@0.19.12':
-    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
+    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==, tarball: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -1348,7 +1345,7 @@ packages:
     os: [linux]
 
   '@esbuild/linux-loong64@0.19.12':
-    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
+    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==, tarball: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -1366,7 +1363,7 @@ packages:
     os: [linux]
 
   '@esbuild/linux-mips64el@0.19.12':
-    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
+    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==, tarball: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -1384,7 +1381,7 @@ packages:
     os: [linux]
 
   '@esbuild/linux-ppc64@0.19.12':
-    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
+    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==, tarball: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -1402,7 +1399,7 @@ packages:
     os: [linux]
 
   '@esbuild/linux-riscv64@0.19.12':
-    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
+    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==, tarball: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -1420,7 +1417,7 @@ packages:
     os: [linux]
 
   '@esbuild/linux-s390x@0.19.12':
-    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
+    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==, tarball: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -1438,7 +1435,7 @@ packages:
     os: [linux]
 
   '@esbuild/linux-x64@0.19.12':
-    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
+    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==, tarball: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -1456,7 +1453,7 @@ packages:
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.19.12':
-    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
+    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==, tarball: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -1474,7 +1471,7 @@ packages:
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.19.12':
-    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
+    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==, tarball: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -1492,7 +1489,7 @@ packages:
     os: [sunos]
 
   '@esbuild/sunos-x64@0.19.12':
-    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
+    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==, tarball: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -1510,7 +1507,7 @@ packages:
     os: [win32]
 
   '@esbuild/win32-arm64@0.19.12':
-    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
+    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==, tarball: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -1528,7 +1525,7 @@ packages:
     os: [win32]
 
   '@esbuild/win32-ia32@0.19.12':
-    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
+    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==, tarball: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -1546,7 +1543,7 @@ packages:
     os: [win32]
 
   '@esbuild/win32-x64@0.19.12':
-    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
+    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==, tarball: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -1690,7 +1687,7 @@ packages:
     resolution: {integrity: sha512-kAFX0c1+N+2WpZaiksy8H4RZ1sytJb2ZFVEmil5Rt6IK8UExU80f0/4kegXIs1KF8a/YyRW0Pybc7svlT9j/wQ==}
 
   '@microsoft/api-extractor@7.43.2':
-    resolution: {integrity: sha512-5bVGdT/fHTDnBk6XPrw4I/U54LIvEeicOOTcyMtBWq387fad+m6tRk2cP/Lg9bz8+/gJgEkTVhpI8FXV4d79Ng==}
+    resolution: {integrity: sha512-5bVGdT/fHTDnBk6XPrw4I/U54LIvEeicOOTcyMtBWq387fad+m6tRk2cP/Lg9bz8+/gJgEkTVhpI8FXV4d79Ng==, tarball: https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.43.2.tgz}
     hasBin: true
 
   '@microsoft/tsdoc-config@0.16.2':
@@ -1752,7 +1749,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==, tarball: https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz}
     engines: {node: '>=14'}
 
   '@pkgr/core@0.1.1':
@@ -2047,7 +2044,7 @@ packages:
         optional: true
 
   '@rollup/rollup-android-arm-eabi@4.11.0':
-    resolution: {integrity: sha512-BV+u2QSfK3i1o6FucqJh5IK9cjAU6icjFFhvknzFgu472jzl0bBojfDAkJLBEsHFMo+YZg6rthBvBBt8z12IBQ==}
+    resolution: {integrity: sha512-BV+u2QSfK3i1o6FucqJh5IK9cjAU6icjFFhvknzFgu472jzl0bBojfDAkJLBEsHFMo+YZg6rthBvBBt8z12IBQ==, tarball: https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.11.0.tgz}
     cpu: [arm]
     os: [android]
 
@@ -2057,7 +2054,7 @@ packages:
     os: [android]
 
   '@rollup/rollup-android-arm64@4.11.0':
-    resolution: {integrity: sha512-0ij3iw7sT5jbcdXofWO2NqDNjSVVsf6itcAkV2I6Xsq4+6wjW1A8rViVB67TfBEan7PV2kbLzT8rhOVWLI2YXw==}
+    resolution: {integrity: sha512-0ij3iw7sT5jbcdXofWO2NqDNjSVVsf6itcAkV2I6Xsq4+6wjW1A8rViVB67TfBEan7PV2kbLzT8rhOVWLI2YXw==, tarball: https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.11.0.tgz}
     cpu: [arm64]
     os: [android]
 
@@ -2067,7 +2064,7 @@ packages:
     os: [android]
 
   '@rollup/rollup-darwin-arm64@4.11.0':
-    resolution: {integrity: sha512-yPLs6RbbBMupArf6qv1UDk6dzZvlH66z6NLYEwqTU0VHtss1wkI4UYeeMS7TVj5QRVvaNAWYKP0TD/MOeZ76Zg==}
+    resolution: {integrity: sha512-yPLs6RbbBMupArf6qv1UDk6dzZvlH66z6NLYEwqTU0VHtss1wkI4UYeeMS7TVj5QRVvaNAWYKP0TD/MOeZ76Zg==, tarball: https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.11.0.tgz}
     cpu: [arm64]
     os: [darwin]
 
@@ -2077,7 +2074,7 @@ packages:
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.11.0':
-    resolution: {integrity: sha512-OvqIgwaGAwnASzXaZEeoJY3RltOFg+WUbdkdfoluh2iqatd090UeOG3A/h0wNZmE93dDew9tAtXgm3/+U/B6bw==}
+    resolution: {integrity: sha512-OvqIgwaGAwnASzXaZEeoJY3RltOFg+WUbdkdfoluh2iqatd090UeOG3A/h0wNZmE93dDew9tAtXgm3/+U/B6bw==, tarball: https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.11.0.tgz}
     cpu: [x64]
     os: [darwin]
 
@@ -2087,7 +2084,7 @@ packages:
     os: [darwin]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.11.0':
-    resolution: {integrity: sha512-X17s4hZK3QbRmdAuLd2EE+qwwxL8JxyVupEqAkxKPa/IgX49ZO+vf0ka69gIKsaYeo6c1CuwY3k8trfDtZ9dFg==}
+    resolution: {integrity: sha512-X17s4hZK3QbRmdAuLd2EE+qwwxL8JxyVupEqAkxKPa/IgX49ZO+vf0ka69gIKsaYeo6c1CuwY3k8trfDtZ9dFg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.11.0.tgz}
     cpu: [arm]
     os: [linux]
 
@@ -2102,7 +2099,7 @@ packages:
     os: [linux]
 
   '@rollup/rollup-linux-arm64-gnu@4.11.0':
-    resolution: {integrity: sha512-673Lu9EJwxVB9NfYeA4AdNu0FOHz7g9t6N1DmT7bZPn1u6bTF+oZjj+fuxUcrfxWXE0r2jxl5QYMa9cUOj9NFg==}
+    resolution: {integrity: sha512-673Lu9EJwxVB9NfYeA4AdNu0FOHz7g9t6N1DmT7bZPn1u6bTF+oZjj+fuxUcrfxWXE0r2jxl5QYMa9cUOj9NFg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.11.0.tgz}
     cpu: [arm64]
     os: [linux]
 
@@ -2112,7 +2109,7 @@ packages:
     os: [linux]
 
   '@rollup/rollup-linux-arm64-musl@4.11.0':
-    resolution: {integrity: sha512-yFW2msTAQNpPJaMmh2NpRalr1KXI7ZUjlN6dY/FhWlOclMrZezm5GIhy3cP4Ts2rIAC+IPLAjNibjp1BsxCVGg==}
+    resolution: {integrity: sha512-yFW2msTAQNpPJaMmh2NpRalr1KXI7ZUjlN6dY/FhWlOclMrZezm5GIhy3cP4Ts2rIAC+IPLAjNibjp1BsxCVGg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.11.0.tgz}
     cpu: [arm64]
     os: [linux]
 
@@ -2127,7 +2124,7 @@ packages:
     os: [linux]
 
   '@rollup/rollup-linux-riscv64-gnu@4.11.0':
-    resolution: {integrity: sha512-kKT9XIuhbvYgiA3cPAGntvrBgzhWkGpBMzuk1V12Xuoqg7CI41chye4HU0vLJnGf9MiZzfNh4I7StPeOzOWJfA==}
+    resolution: {integrity: sha512-kKT9XIuhbvYgiA3cPAGntvrBgzhWkGpBMzuk1V12Xuoqg7CI41chye4HU0vLJnGf9MiZzfNh4I7StPeOzOWJfA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.11.0.tgz}
     cpu: [riscv64]
     os: [linux]
 
@@ -2142,7 +2139,7 @@ packages:
     os: [linux]
 
   '@rollup/rollup-linux-x64-gnu@4.11.0':
-    resolution: {integrity: sha512-6q4ESWlyTO+erp1PSCmASac+ixaDv11dBk1fqyIuvIUc/CmRAX2Zk+2qK1FGo5q7kyDcjHCFVwgGFCGIZGVwCA==}
+    resolution: {integrity: sha512-6q4ESWlyTO+erp1PSCmASac+ixaDv11dBk1fqyIuvIUc/CmRAX2Zk+2qK1FGo5q7kyDcjHCFVwgGFCGIZGVwCA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.11.0.tgz}
     cpu: [x64]
     os: [linux]
 
@@ -2152,7 +2149,7 @@ packages:
     os: [linux]
 
   '@rollup/rollup-linux-x64-musl@4.11.0':
-    resolution: {integrity: sha512-vIAQUmXeMLmaDN78HSE4Kh6xqof2e3TJUKr+LPqXWU4NYNON0MDN9h2+t4KHrPAQNmU3w1GxBQ/n01PaWFwa5w==}
+    resolution: {integrity: sha512-vIAQUmXeMLmaDN78HSE4Kh6xqof2e3TJUKr+LPqXWU4NYNON0MDN9h2+t4KHrPAQNmU3w1GxBQ/n01PaWFwa5w==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.11.0.tgz}
     cpu: [x64]
     os: [linux]
 
@@ -2162,7 +2159,7 @@ packages:
     os: [linux]
 
   '@rollup/rollup-win32-arm64-msvc@4.11.0':
-    resolution: {integrity: sha512-LVXo9dDTGPr0nezMdqa1hK4JeoMZ02nstUxGYY/sMIDtTYlli1ZxTXBYAz3vzuuvKO4X6NBETciIh7N9+abT1g==}
+    resolution: {integrity: sha512-LVXo9dDTGPr0nezMdqa1hK4JeoMZ02nstUxGYY/sMIDtTYlli1ZxTXBYAz3vzuuvKO4X6NBETciIh7N9+abT1g==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.11.0.tgz}
     cpu: [arm64]
     os: [win32]
 
@@ -2172,7 +2169,7 @@ packages:
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.11.0':
-    resolution: {integrity: sha512-xZVt6K70Gr3I7nUhug2dN6VRR1ibot3rXqXS3wo+8JP64t7djc3lBFyqO4GiVrhNaAIhUCJtwQ/20dr0h0thmQ==}
+    resolution: {integrity: sha512-xZVt6K70Gr3I7nUhug2dN6VRR1ibot3rXqXS3wo+8JP64t7djc3lBFyqO4GiVrhNaAIhUCJtwQ/20dr0h0thmQ==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.11.0.tgz}
     cpu: [ia32]
     os: [win32]
 
@@ -2182,7 +2179,7 @@ packages:
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.11.0':
-    resolution: {integrity: sha512-f3I7h9oTg79UitEco9/2bzwdciYkWr8pITs3meSDSlr1TdvQ7IxkQaaYN2YqZXX5uZhiYL+VuYDmHwNzhx+HOg==}
+    resolution: {integrity: sha512-f3I7h9oTg79UitEco9/2bzwdciYkWr8pITs3meSDSlr1TdvQ7IxkQaaYN2YqZXX5uZhiYL+VuYDmHwNzhx+HOg==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.11.0.tgz}
     cpu: [x64]
     os: [win32]
 
@@ -2557,7 +2554,7 @@ packages:
     resolution: {integrity: sha512-2bkg93YBSDKk8DLmmHnmj/Rwr18TLx7/n+I23BigFwgexUJoMHZOd8X1OFxuF/W3NN0S2W2E5sVabI5CPinNvA==}
 
   '@types/node@20.12.10':
-    resolution: {integrity: sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==}
+    resolution: {integrity: sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==, tarball: https://registry.npmjs.org/@types/node/-/node-20.12.10.tgz}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -2828,7 +2825,7 @@ packages:
     engines: {node: '>=6'}
 
   ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==, tarball: https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz}
     engines: {node: '>=8'}
 
   ansi-regex@6.0.1:
@@ -2840,7 +2837,7 @@ packages:
     engines: {node: '>=4'}
 
   ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==, tarball: https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz}
     engines: {node: '>=8'}
 
   ansi-styles@6.2.1:
@@ -3282,14 +3279,14 @@ packages:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
 
   color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==, tarball: https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz}
     engines: {node: '>=7.0.0'}
 
   color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==, tarball: https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz}
 
   color2k@2.0.3:
     resolution: {integrity: sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==}
@@ -3324,7 +3321,7 @@ packages:
     engines: {node: '>= 12'}
 
   commander@9.5.0:
-    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==, tarball: https://registry.npmjs.org/commander/-/commander-9.5.0.tgz}
     engines: {node: ^12.20.0 || >=14}
 
   commondir@1.0.1:
@@ -3654,7 +3651,7 @@ packages:
     resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
 
   emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==, tarball: https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
@@ -4300,7 +4297,7 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -4729,7 +4726,7 @@ packages:
     engines: {node: '>=4'}
 
   is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==, tarball: https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz}
     engines: {node: '>=8'}
 
   is-fullwidth-code-point@4.0.0:
@@ -5659,7 +5656,7 @@ packages:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.7:
-    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==, tarball: https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5977,7 +5974,7 @@ packages:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
 
   picocolors@1.0.0:
-    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==, tarball: https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz}
 
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -6109,7 +6106,7 @@ packages:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.4.38:
-    resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
+    resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==, tarball: https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz}
     engines: {node: ^10 || ^12 || >=14}
 
   preferred-pm@3.1.2:
@@ -6700,7 +6697,7 @@ packages:
     hasBin: true
 
   source-map-js@1.2.0:
-    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==, tarball: https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz}
     engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.21:
@@ -6775,7 +6772,7 @@ packages:
     engines: {node: '>=6'}
 
   string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==, tarball: https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz}
     engines: {node: '>=8'}
 
   string-width@5.1.2:
@@ -6835,7 +6832,7 @@ packages:
     engines: {node: '>=6'}
 
   strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==, tarball: https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz}
     engines: {node: '>=8'}
 
   strip-ansi@7.1.0:
@@ -7231,7 +7228,7 @@ packages:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
   undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz}
 
   undici@6.15.0:
     resolution: {integrity: sha512-VviMt2tlMg1BvQ0FKXxrz1eJuyrcISrL2sPfBf7ZskX/FCEc/7LeThQaoygsMJpNqrATWQIsRVx+1Dpe4jaYuQ==}
@@ -7571,7 +7568,7 @@ packages:
     engines: {node: '>=8'}
 
   wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==, tarball: https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz}
     engines: {node: '>=10'}
 
   wrap-ansi@8.1.0:
@@ -9167,6 +9164,7 @@ snapshots:
       '@rushstack/node-core-library': 4.2.0(@types/node@20.12.10)
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
   '@microsoft/api-extractor@7.43.2(@types/node@20.12.10)':
     dependencies:
@@ -9185,6 +9183,7 @@ snapshots:
       typescript: 5.4.2
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
   '@microsoft/tsdoc-config@0.16.2':
     dependencies:
@@ -9734,11 +9733,13 @@ snapshots:
       z-schema: 5.0.5
     optionalDependencies:
       '@types/node': 20.12.10
+    optional: true
 
   '@rushstack/rig-package@0.5.2':
     dependencies:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
+    optional: true
 
   '@rushstack/terminal@0.10.2(@types/node@20.12.10)':
     dependencies:
@@ -9746,6 +9747,7 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 20.12.10
+    optional: true
 
   '@rushstack/ts-command-line@4.19.3(@types/node@20.12.10)':
     dependencies:
@@ -9755,6 +9757,7 @@ snapshots:
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
   '@shikijs/core@1.4.0': {}
 
@@ -10342,7 +10345,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.5
 
-  '@types/argparse@1.0.38': {}
+  '@types/argparse@1.0.38':
+    optional: true
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -13325,7 +13329,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-lazy@4.0.0: {}
+  import-lazy@4.0.0:
+    optional: true
 
   import-meta-resolve@4.0.0: {}
 
@@ -13826,9 +13831,11 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
-  lodash.get@4.4.2: {}
+  lodash.get@4.4.2:
+    optional: true
 
-  lodash.isequal@4.5.0: {}
+  lodash.isequal@4.5.0:
+    optional: true
 
   lodash.merge@4.6.2: {}
 
@@ -14641,6 +14648,7 @@ snapshots:
   minimatch@3.0.8:
     dependencies:
       brace-expansion: 1.1.11
+    optional: true
 
   minimatch@3.1.2:
     dependencies:
@@ -15757,6 +15765,7 @@ snapshots:
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
+    optional: true
 
   semver@7.6.0:
     dependencies:
@@ -16251,6 +16260,7 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+    optional: true
 
   supports-color@9.4.0: {}
 
@@ -16566,7 +16576,8 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@5.4.2: {}
+  typescript@5.4.2:
+    optional: true
 
   typescript@5.4.5: {}
 
@@ -16814,7 +16825,8 @@ snapshots:
     dependencies:
       builtins: 5.1.0
 
-  validator@13.11.0: {}
+  validator@13.11.0:
+    optional: true
 
   vary@1.1.2: {}
 
@@ -17121,5 +17133,6 @@ snapshots:
       validator: 13.11.0
     optionalDependencies:
       commander: 9.5.0
+    optional: true
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
### Use `tsc` to generate types

- Faster type generation
- Output declaration maps, makes "go to declaration" nicer, same as in java/intellij when you get the actual source code

### Wire up dot notations inline, not in index

Makes "Go to reference" go to the actual file, not the index file. Same as [NAV does it](https://github.com/navikt/aksel/blob/main/%40navikt/core/react/src/accordion/Accordion.tsx#L110-L114)