### PR TITLE
♻️ No prefix props for badge & button

### DIFF
--- a/.changeset/clever-ways-march.md
+++ b/.changeset/clever-ways-march.md
@@ -1,0 +1,6 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+:recycle: badge: make badge variant as props, not prefix in component name

--- a/.changeset/fair-geese-type.md
+++ b/.changeset/fair-geese-type.md
@@ -1,0 +1,6 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+:recycle: button: make button variants as props, not prefix in component name

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ This package has three packages
 The simplest way is to just install the `@postenbring/hedwig-react` package, and start using the components. The css is imported in the javascript files so a bundler that supports side effect imports is required. Vite and Remix supports this out of the box.
 
 ```tsx
-import { Box, PrimaryButton } from "@postenbring/hedwig-react";
+import { Box, Button } from "@postenbring/hedwig-react";
 
 export function MyComponent() {
   return (
     <Box>
-      <PrimaryButton>Hello, World</PrimaryButton>
+      <Button>Hello, World</Button>
     </Box>
   );
 }
@@ -124,7 +124,7 @@ We use [changesets](https://github.com/changesets/changesets) to handle publishi
 "@postenbring/hedwig-react": patch
 ---
 
-:lipstick: Change font size on PrimaryButton component.
+:lipstick: Change font size on Button component.
 ```
 
 This changeset file will create patch releases of the `@postenbring/hedwig-css` and `@postenbring/hedwig-react` packages.

--- a/apps/examples/app/components/code-example.tsx
+++ b/apps/examples/app/components/code-example.tsx
@@ -10,7 +10,7 @@ import "@postenbring/hedwig-css";
 import styles from "./code-example.module.css";
 
 import { Example } from "../examples";
-import { SecondaryButton, StyledHtml, type ButtonProps } from "@postenbring/hedwig-react";
+import { Button, StyledHtml, type ButtonProps } from "@postenbring/hedwig-react";
 import { openExampleInCodeSandbox } from "./codesandbox";
 import { useSearchParams } from "@remix-run/react";
 
@@ -147,39 +147,44 @@ export function CodeExample({
 
         {/* Actions row */}
         <div>
-          <SecondaryButton
+          <Button
+            variant="secondary-outline"
             onClick={() => {
               if (iframeRef.current) {
                 iframeRef.current.style.width = "360px";
               }
             }}
             title="Mobile"
-            fill="outline"
             size="small"
             icon
           >
             📱
-          </SecondaryButton>
-          <SecondaryButton
+          </Button>
+          <Button
+            variant="secondary-outline"
             onClick={() => {
               if (iframeRef.current) {
                 iframeRef.current.style.width = "";
               }
             }}
             title="Desktop"
-            fill="outline"
             size="small"
             icon
           >
             🖥️
-          </SecondaryButton>
+          </Button>
           <div style={{ flexGrow: 1 }} />
 
-          <SecondaryButton fill="outline" size="small" onClick={() => setShowCode((prev) => !prev)}>
+          <Button
+            variant="secondary-outline"
+            size="small"
+            onClick={() => setShowCode((prev) => !prev)}
+          >
             {showCode ? "Hide code" : "Show code"}
-          </SecondaryButton>
+          </Button>
 
-          <SecondaryButton
+          <Button
+            variant="secondary"
             title="Open in CodeSandbox"
             size="small"
             onClick={() => openExampleInCodeSandbox(activeExample)}
@@ -188,8 +193,8 @@ export function CodeExample({
             <svg aria-hidden="true" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path d="M0 24H24V0H0V2.45455H21.5455V21.5455H2.45455V0H0Z" />
             </svg>
-          </SecondaryButton>
-          <SecondaryButton size="small" icon asChild>
+          </Button>
+          <Button variant="secondary" size="small" icon asChild>
             <a
               href={iframeUrl(activeExample)}
               target="_blank"
@@ -212,7 +217,7 @@ export function CodeExample({
                 />
               </svg>
             </a>
-          </SecondaryButton>
+          </Button>
         </div>
       </div>
 
@@ -235,7 +240,8 @@ function CopyButton({
 }) {
   const [copied, setCopied] = useState(false);
   return (
-    <SecondaryButton
+    <Button
+      variant="secondary"
       onClick={async () => {
         navigator.clipboard.writeText(code);
         setCopied(true);
@@ -246,7 +252,7 @@ function CopyButton({
       {...rest}
     >
       {copied ? "Copied" : "Copy"}
-    </SecondaryButton>
+    </Button>
   );
 }
 

--- a/apps/examples/app/examples/badge/dark.tsx
+++ b/apps/examples/app/examples/badge/dark.tsx
@@ -1,10 +1,12 @@
-import { DarkBadge, HStack } from "@postenbring/hedwig-react";
+import { Badge, HStack } from "@postenbring/hedwig-react";
 
 function Example() {
   return (
     <HStack gap="8" align="end">
-      <DarkBadge>Dark</DarkBadge>
-      <DarkBadge size="smaller">Dark</DarkBadge>
+      <Badge variant="dark">Dark</Badge>
+      <Badge variant="dark" size="smaller">
+        Dark
+      </Badge>
     </HStack>
   );
 }

--- a/apps/examples/app/examples/badge/warning.tsx
+++ b/apps/examples/app/examples/badge/warning.tsx
@@ -1,10 +1,10 @@
-import { HStack, WarningBadge } from "@postenbring/hedwig-react";
+import { HStack, Badge } from "@postenbring/hedwig-react";
 
 function Example() {
   return (
     <HStack gap="8" align="end">
-      <WarningBadge>Warning</WarningBadge>
-      <WarningBadge size="smaller">Warning</WarningBadge>
+      <Badge variant="warning">Warning</Badge>
+      <Badge size="smaller">Warning</Badge>
     </HStack>
   );
 }

--- a/apps/examples/app/examples/badge/white.tsx
+++ b/apps/examples/app/examples/badge/white.tsx
@@ -1,11 +1,13 @@
-import { Box, HStack, WhiteBadge } from "@postenbring/hedwig-react";
+import { Box, HStack, Badge } from "@postenbring/hedwig-react";
 
 function Example() {
   return (
     <Box>
       <HStack gap="8" align="end">
-        <WhiteBadge>White</WhiteBadge>
-        <WhiteBadge size="smaller">White</WhiteBadge>
+        <Badge variant="white">White</Badge>
+        <Badge variant="white" size="smaller">
+          White
+        </Badge>
       </HStack>
     </Box>
   );

--- a/apps/examples/app/examples/button/action.tsx
+++ b/apps/examples/app/examples/button/action.tsx
@@ -1,12 +1,12 @@
-import { PrimaryButton, HStack } from "@postenbring/hedwig-react";
+import { Button, HStack } from "@postenbring/hedwig-react";
 
 function Example() {
   return (
     <HStack gap="8" wrap>
-      <PrimaryButton fullWidth="mobile">Main action</PrimaryButton>
-      <PrimaryButton fill="outline" fullWidth="mobile">
+      <Button fullWidth="mobile">Main action</Button>
+      <Button variant="primary-outline" fullWidth="mobile">
         Alternative action
-      </PrimaryButton>
+      </Button>
     </HStack>
   );
 }

--- a/apps/examples/app/examples/button/fullwidth-on-mobile.tsx
+++ b/apps/examples/app/examples/button/fullwidth-on-mobile.tsx
@@ -1,7 +1,7 @@
-import { PrimaryButton } from "@postenbring/hedwig-react";
+import { Button } from "@postenbring/hedwig-react";
 
 function Example() {
-  return <PrimaryButton fullWidth="mobile">Submit</PrimaryButton>;
+  return <Button fullWidth="mobile">Submit</Button>;
 }
 
 export default Example;

--- a/apps/examples/app/examples/button/primary.tsx
+++ b/apps/examples/app/examples/button/primary.tsx
@@ -1,23 +1,23 @@
-import { PrimaryButton, HStack, VStack } from "@postenbring/hedwig-react";
+import { Button, HStack, VStack } from "@postenbring/hedwig-react";
 
 function Example() {
   return (
     <VStack gap="24">
       <HStack gap="24" wrap align="end">
-        <PrimaryButton size="large">Call to action</PrimaryButton>
-        <PrimaryButton size="medium">Call to action</PrimaryButton>
-        <PrimaryButton size="small">Call to action</PrimaryButton>
+        <Button size="large">Call to action</Button>
+        <Button size="medium">Call to action</Button>
+        <Button size="small">Call to action</Button>
       </HStack>
       <HStack gap="24" wrap align="end">
-        <PrimaryButton fill="outline" size="large">
+        <Button variant="primary-outline" size="large">
           Call to action
-        </PrimaryButton>
-        <PrimaryButton fill="outline" size="medium">
+        </Button>
+        <Button variant="primary-outline" size="medium">
           Call to action
-        </PrimaryButton>
-        <PrimaryButton fill="outline" size="small">
+        </Button>
+        <Button variant="primary-outline" size="small">
           Call to action
-        </PrimaryButton>
+        </Button>
       </HStack>
     </VStack>
   );

--- a/apps/examples/app/examples/button/secondary.tsx
+++ b/apps/examples/app/examples/button/secondary.tsx
@@ -1,23 +1,29 @@
-import { HStack, SecondaryButton, VStack } from "@postenbring/hedwig-react";
+import { HStack, Button, VStack } from "@postenbring/hedwig-react";
 
 function Example() {
   return (
     <VStack gap="24">
       <HStack gap="24" wrap align="end">
-        <SecondaryButton size="large">Call to action</SecondaryButton>
-        <SecondaryButton size="medium">Call to action</SecondaryButton>
-        <SecondaryButton size="small">Call to action</SecondaryButton>
+        <Button variant="secondary" size="large">
+          Call to action
+        </Button>
+        <Button variant="secondary" size="medium">
+          Call to action
+        </Button>
+        <Button variant="secondary" size="small">
+          Call to action
+        </Button>
       </HStack>
       <HStack gap="24" wrap align="end">
-        <SecondaryButton fill="outline" size="large">
+        <Button variant="secondary-outline" size="large">
           Call to action
-        </SecondaryButton>
-        <SecondaryButton fill="outline" size="medium">
+        </Button>
+        <Button variant="secondary-outline" size="medium">
           Call to action
-        </SecondaryButton>
-        <SecondaryButton fill="outline" size="small">
+        </Button>
+        <Button variant="secondary-outline" size="small">
           Call to action
-        </SecondaryButton>
+        </Button>
       </HStack>
     </VStack>
   );

--- a/apps/examples/app/examples/form/input/demo.tsx
+++ b/apps/examples/app/examples/form/input/demo.tsx
@@ -1,11 +1,4 @@
-import {
-  Container,
-  Input,
-  PrimaryButton,
-  Select,
-  Textarea,
-  VStack,
-} from "@postenbring/hedwig-react";
+import { Container, Input, Button, Select, Textarea, VStack } from "@postenbring/hedwig-react";
 
 function Example() {
   function onSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -32,7 +25,7 @@ function Example() {
             <option value="cat">Cat</option>
             <option value="other">Other</option>
           </Select>
-          <PrimaryButton>Submit</PrimaryButton>
+          <Button>Submit</Button>
         </VStack>
       </form>
     </Container>

--- a/apps/examples/app/examples/modal/auto-open.tsx
+++ b/apps/examples/app/examples/modal/auto-open.tsx
@@ -1,4 +1,4 @@
-import { Modal, SecondaryButton } from "@postenbring/hedwig-react";
+import { Modal, Button } from "@postenbring/hedwig-react";
 
 function Example() {
   return (
@@ -13,14 +13,14 @@ function Example() {
         </Modal.Content>
       </Modal>
 
-      <SecondaryButton
+      <Button
+        variant="secondary-outline"
         onClick={() => {
           window.location.reload();
         }}
         icon
         size="large"
         title="Refresh"
-        fill="outline"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -37,7 +37,7 @@ function Example() {
             d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
           />
         </svg>
-      </SecondaryButton>
+      </Button>
     </>
   );
 }

--- a/apps/examples/app/examples/modal/demo.tsx
+++ b/apps/examples/app/examples/modal/demo.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { HStack, Modal, PrimaryButton } from "@postenbring/hedwig-react";
+import { HStack, Modal, Button } from "@postenbring/hedwig-react";
 
 function Example() {
   const modalRef = useRef<HTMLDialogElement>(null);
@@ -8,7 +8,7 @@ function Example() {
 
   return (
     <>
-      <PrimaryButton onClick={() => modalRef.current?.showModal()}>Open Modal</PrimaryButton>
+      <Button onClick={() => modalRef.current?.showModal()}>Open Modal</Button>
       <Modal ref={modalRef}>
         <Modal.Header>Dialog header</Modal.Header>
         <Modal.Content>
@@ -19,10 +19,10 @@ function Example() {
         </Modal.Content>
         <Modal.Footer>
           <HStack gap="16" wrap>
-            <PrimaryButton onClick={onMainAction}>Main action</PrimaryButton>
-            <PrimaryButton fill="outline" onClick={onClose}>
+            <Button onClick={onMainAction}>Main action</Button>
+            <Button variant="primary-outline" onClick={onClose}>
               Cancel
-            </PrimaryButton>
+            </Button>
           </HStack>
         </Modal.Footer>
       </Modal>

--- a/apps/examples/app/examples/patterns/css/fine-grained-imports.tsx
+++ b/apps/examples/app/examples/patterns/css/fine-grained-imports.tsx
@@ -7,7 +7,7 @@ import "@postenbring/hedwig-css/dist/box.css";
 import "@postenbring/hedwig-css/dist/button.css";
 import "@postenbring/hedwig-css/dist/text.css";
 
-import { Box, PrimaryButton, Text } from "@postenbring/hedwig-react/dist/index-no-css";
+import { Box, Button, Text } from "@postenbring/hedwig-react/dist/index-no-css";
 
 function Example() {
   return (
@@ -15,7 +15,7 @@ function Example() {
       <Text as="h1" variant="body-title">
         A button
       </Text>
-      <PrimaryButton>Submit</PrimaryButton>
+      <Button>Submit</Button>
     </Box>
   );
 }

--- a/apps/examples/app/examples/patterns/polymorphism/links-and-buttons.tsx
+++ b/apps/examples/app/examples/patterns/polymorphism/links-and-buttons.tsx
@@ -1,13 +1,13 @@
-import { Link, PrimaryButton, VStack } from "@postenbring/hedwig-react";
+import { Link, Button, VStack } from "@postenbring/hedwig-react";
 
 function Example() {
   return (
     <VStack gap="24">
-      <PrimaryButton asChild>
+      <Button asChild>
         <a href="https://www.posten.no" target="_blank" rel="noopener noreferrer">
           A link that looks like a button
         </a>
-      </PrimaryButton>
+      </Button>
       <Link asChild>
         <button onClick={() => alert("Button clicked!")}>A button that looks like a link</button>
       </Link>

--- a/apps/examples/app/examples/patterns/tailwind/with-react.tsx
+++ b/apps/examples/app/examples/patterns/tailwind/with-react.tsx
@@ -1,4 +1,4 @@
-import { PrimaryButton } from "@postenbring/hedwig-react";
+import { Button } from "@postenbring/hedwig-react";
 import "./tailwind.css";
 
 function Example() {
@@ -10,7 +10,7 @@ function Example() {
         <div className="transition-all rounded size-48 hover:scale-125 bg-signature hover:bg-darker" />
       </div>
       <div>
-        <PrimaryButton>Primary Button</PrimaryButton>
+        <Button>Primary Button</Button>
       </div>
     </div>
   );

--- a/apps/examples/app/examples/step-indicator/demo.tsx
+++ b/apps/examples/app/examples/step-indicator/demo.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { HStack, StepIndicator, PrimaryButton, VStack, Skeleton } from "@postenbring/hedwig-react";
+import { HStack, StepIndicator, Button, VStack, Skeleton } from "@postenbring/hedwig-react";
 
 const steps = ["Size and weight", "Sender", "Recipient", "Summary"];
 function Example() {
@@ -21,24 +21,25 @@ function Example() {
         </div>
         <HStack gap="12">
           {activeStep > 1 && (
-            <PrimaryButton fill="outline" onClick={() => setActiveStep((current) => current - 1)}>
+            <Button
+              variant="primary-outline"
+              onClick={() => setActiveStep((current) => current - 1)}
+            >
               Back
-            </PrimaryButton>
+            </Button>
           )}
           {activeStep < steps.length && (
-            <PrimaryButton onClick={() => setActiveStep((current) => current + 1)}>
-              Continue
-            </PrimaryButton>
+            <Button onClick={() => setActiveStep((current) => current + 1)}>Continue</Button>
           )}
 
           {activeStep === steps.length && (
-            <PrimaryButton
+            <Button
               onClick={() => {
                 //
               }}
             >
               Submit order
-            </PrimaryButton>
+            </Button>
           )}
         </HStack>
       </VStack>

--- a/apps/examples/app/routes/_layout.tsx
+++ b/apps/examples/app/routes/_layout.tsx
@@ -4,7 +4,7 @@ import {
   Footer,
   HStack,
   Navbar,
-  PrimaryButton,
+  Button,
   VStack,
   useNavbarExpendableMenuContext,
 } from "@postenbring/hedwig-react";
@@ -74,7 +74,7 @@ export default function Layout() {
           </RemixLink>
         </Navbar.LinkItem>
         <Navbar.Item>
-          <PrimaryButton fill="outline" size="small" asChild>
+          <Button variant="primary-outline" size="small" asChild>
             <RemixLink
               to={{
                 search:
@@ -87,7 +87,7 @@ export default function Layout() {
             >
               {kebabCaseToFirstLetterUpperCase(activeTheme)}
             </RemixLink>
-          </PrimaryButton>
+          </Button>
         </Navbar.Item>
       </>
     );

--- a/packages/css/src/button/button.css
+++ b/packages/css/src/button/button.css
@@ -109,7 +109,7 @@
     }
   }
 
-  &.hds-button--outline-primary {
+  &.hds-button--primary-outline {
     --hds-component-button-border-width: var(--hds-stroke-default);
 
     background-color: transparent;
@@ -126,7 +126,7 @@
     }
   }
 
-  &.hds-button--outline-secondary {
+  &.hds-button--secondary-outline {
     --hds-component-button-border-width: var(--hds-stroke-default);
 
     background-color: transparent;
@@ -143,7 +143,7 @@
     }
   }
 
-  &.hds-button--outline-white {
+  &.hds-button--white-outline {
     --hds-component-button-border-width: var(--hds-stroke-default);
 
     background-color: transparent;
@@ -177,8 +177,8 @@
       cursor: default;
     }
 
-    &.hds-button--outline-primary,
-    &.hds-button--outline-secondary {
+    &.hds-button--primary-outline,
+    &.hds-button--secondary-outline {
       border-color: var(--hds-ui-colors-grey);
       color: var(--hds-ui-colors-dark-grey);
       fill: var(--hds-ui-colors-dark-grey);

--- a/packages/react/src/badge/badge.stories.tsx
+++ b/packages/react/src/badge/badge.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies -- storybook story */
 import type { Meta, StoryObj } from "@storybook/react";
 import { Box } from "../box";
-import { Badge, DarkBadge, WhiteBadge, WarningBadge } from ".";
+import { Badge } from ".";
 
 const meta: Meta<typeof Badge> = {
   title: "Badge",
@@ -14,31 +14,33 @@ type Story = StoryObj<typeof Badge>;
 
 export const Lighter: Story = {
   args: {
+    variant: "lighter",
     children: "Default badge",
   },
 };
 
 export const Dark: Story = {
   args: {
+    variant: "dark",
     children: "Dark badge",
   },
-  render: (props) => <DarkBadge {...props} />,
 };
 
 export const White: Story = {
   args: {
+    variant: "white",
     children: "White badge",
   },
   render: (props) => (
     <Box>
-      <WhiteBadge {...props} />
+      <Badge {...props} />
     </Box>
   ),
 };
 
 export const Warning: Story = {
   args: {
+    variant: "warning",
     children: "Warning badge",
   },
-  render: (props) => <WarningBadge {...props} />,
 };

--- a/packages/react/src/badge/badge.tsx
+++ b/packages/react/src/badge/badge.tsx
@@ -6,6 +6,13 @@ export interface BadgeProps extends React.AnchorHTMLAttributes<HTMLSpanElement> 
   children: React.ReactNode;
 
   /**
+   * Color of the badge
+   *
+   * @default "lighter"
+   */
+  variant?: "lighter" | "dark" | "white" | "warning";
+
+  /**
    * Font size of the badge
    *
    * @default "small"
@@ -20,44 +27,29 @@ export interface BadgeProps extends React.AnchorHTMLAttributes<HTMLSpanElement> 
   asChild?: boolean;
 }
 
-const Badge = forwardRef<
-  HTMLSpanElement,
-  BadgeProps & { variant: "lighter" | "dark" | "white" | "warning" }
->(({ children, asChild, variant, size = "small", className, ...rest }, ref) => {
-  const Component = asChild ? Slot : "span";
-  return (
-    <Component
-      ref={ref}
-      className={clsx(
-        "hds-badge",
-        `hds-badge--${size}`,
-        `hds-badge--${variant}`,
-        className as undefined,
-      )}
-      {...rest}
-    >
-      {children}
-    </Component>
-  );
-});
+/**
+ * Badges are used to label, categorize or organize items using keywords to describe them.
+ *
+ * @example
+ * <Badge variant="dark">Dark</Badge>
+ */
+export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ children, asChild, variant = "lighter", size = "small", className, ...rest }, ref) => {
+    const Component = asChild ? Slot : "span";
+    return (
+      <Component
+        ref={ref}
+        className={clsx(
+          "hds-badge",
+          `hds-badge--${size}`,
+          `hds-badge--${variant}`,
+          className as undefined,
+        )}
+        {...rest}
+      >
+        {children}
+      </Component>
+    );
+  },
+);
 Badge.displayName = "Badge";
-
-export const LighterBadge = forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
-  return <Badge {...props} ref={ref} variant="lighter" />;
-});
-LighterBadge.displayName = "LighterBadge";
-
-export const DarkBadge = forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
-  return <Badge {...props} ref={ref} variant="dark" />;
-});
-DarkBadge.displayName = "DarkBadge";
-
-export const WhiteBadge = forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
-  return <Badge {...props} ref={ref} variant="white" />;
-});
-WhiteBadge.displayName = "WhiteBadge";
-
-export const WarningBadge = forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
-  return <Badge {...props} ref={ref} variant="warning" />;
-});
-WarningBadge.displayName = "WarningBadge";

--- a/packages/react/src/badge/index.tsx
+++ b/packages/react/src/badge/index.tsx
@@ -1,3 +1,3 @@
-export { LighterBadge as Badge, DarkBadge, WarningBadge, WhiteBadge } from "./badge";
+export { Badge } from "./badge";
 
 export type * from "./badge";

--- a/packages/react/src/button/button.stories.tsx
+++ b/packages/react/src/button/button.stories.tsx
@@ -2,11 +2,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { HStack } from "../layout";
 import type { ButtonProps } from ".";
-import { PrimaryButton, SecondaryButton } from ".";
+import { Button } from ".";
 
-const meta: Meta<typeof PrimaryButton> = {
+const meta: Meta<typeof Button> = {
   title: "Button",
-  component: PrimaryButton,
+  component: Button,
   argTypes: {
     fullWidth: { control: "radio", options: [false, true, "mobile"] },
   },
@@ -14,33 +14,33 @@ const meta: Meta<typeof PrimaryButton> = {
 
 export default meta;
 
-type Story = StoryObj<typeof PrimaryButton>;
+type Story = StoryObj<typeof Button>;
 
 export const Primary: Story = {
   args: {
+    variant: "primary",
     children: "Primary button",
   },
 };
 
 export const PrimaryOutline: Story = {
   args: {
+    variant: "primary-outline",
     children: "Primary outline button",
-    fill: "outline",
   },
 };
 
 export const Secondary: Story = {
   args: {
+    variant: "secondary",
     children: "Secondary button",
   },
-  render: (props) => <SecondaryButton {...props} />,
 };
 
 export const SecondaryOutline: Story = {
-  render: (props) => <SecondaryButton {...props} />,
   args: {
+    variant: "secondary-outline",
     children: "Secondary outline button",
-    fill: "outline",
   },
 };
 
@@ -48,10 +48,10 @@ export const AsALink: Story = {
   name: "As a link",
   render: (args) => (
     <HStack gap="16" wrap>
-      <PrimaryButton {...args} />
-      <PrimaryButton {...args} fill="outline" />
-      <SecondaryButton {...args} />
-      <SecondaryButton {...args} fill="outline" />
+      <Button {...args} variant="primary" />
+      <Button {...args} variant="primary-outline" />
+      <Button {...args} variant="secondary" />
+      <Button {...args} variant="secondary-outline" />
     </HStack>
   ),
   args: {
@@ -65,7 +65,7 @@ export const AsALink: Story = {
 };
 
 const createIconStory = (
-  Component: typeof PrimaryButton,
+  Component: typeof Button,
   extraArgs: Partial<ButtonProps> = {},
 ): Story => ({
   render: (args) => (
@@ -98,7 +98,9 @@ const createIconStory = (
   },
 });
 
-export const IconPrimary: Story = createIconStory(PrimaryButton);
-export const IconPrimaryOutline: Story = createIconStory(PrimaryButton, { fill: "outline" });
-export const IconSecondary: Story = createIconStory(SecondaryButton);
-export const IconSecondaryOutline: Story = createIconStory(SecondaryButton, { fill: "outline" });
+export const IconPrimary: Story = createIconStory(Button, { variant: "secondary" });
+export const IconPrimaryOutline: Story = createIconStory(Button, { variant: "primary-outline" });
+export const IconSecondary: Story = createIconStory(Button, { variant: "secondary" });
+export const IconSecondaryOutline: Story = createIconStory(Button, {
+  variant: "secondary-outline",
+});

--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -9,11 +9,11 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   size?: "small" | "medium" | "large";
 
   /**
-   * The background fill of the button
+   * The background and fill of the button
    *
-   * @default "contained"
+   * @default "primary"
    */
-  fill?: "contained" | "outline";
+  variant?: "primary" | "secondary" | "primary-outline" | "secondary-outline";
 
   /**
    * Make the button use 100% width available.
@@ -36,15 +36,27 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   asChild?: boolean;
 }
 
-const Button = forwardRef<HTMLButtonElement, ButtonProps & { variant: "primary" | "secondary" }>(
+/**
+ * Button component
+ *
+ * @example
+ * <Button variant="primary">Primary</Button>
+ * <Button variant="secondary" size="large">Secondary</Button>
+ * <Button variant="primary-outline">Primary Outline</Button>
+ * <Button variant="secondary-outline" fullWidth="mobile">Secondary Outline</Button>
+ *
+ * @example
+ * // If used for navigation use the `asChild` prop with a anchor element as a child.
+ * <Button asChild><a href="/home">Home</a></Button>
+ */
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       asChild,
       children,
-      variant,
+      variant = "primary",
       size = "medium",
       fullWidth = false,
-      fill = "contained",
       icon,
       className,
       ...rest
@@ -57,9 +69,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps & { variant: "primary" 
         className={clsx(
           "hds-button",
           `hds-button--${size}`,
+          `hds-button--${variant}`,
           {
-            [`hds-button--${variant}`]: fill === "contained",
-            [`hds-button--outline-${variant}`]: fill === "outline",
             "hds-button--full": fullWidth === true,
             "hds-button--mobile-full": fullWidth === "mobile",
             "hds-button--icon-only": icon,
@@ -75,13 +86,3 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps & { variant: "primary" 
   },
 );
 Button.displayName = "Button";
-
-export const PrimaryButton = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
-  return <Button {...props} ref={ref} variant="primary" />;
-});
-PrimaryButton.displayName = "PrimaryButton";
-
-export const SecondaryButton = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
-  return <Button {...props} ref={ref} variant="secondary" />;
-});
-SecondaryButton.displayName = "SecondaryButton";

--- a/packages/react/src/button/index.tsx
+++ b/packages/react/src/button/index.tsx
@@ -1,3 +1,3 @@
-export { PrimaryButton, SecondaryButton } from "./button";
+export { Button } from "./button";
 
 export type * from "./button";

--- a/packages/react/src/footer/footer.tsx
+++ b/packages/react/src/footer/footer.tsx
@@ -3,7 +3,7 @@ import { clsx } from "@postenbring/hedwig-css/typed-classname";
 import { Slot } from "@radix-ui/react-slot";
 import { Accordion } from "../accordion";
 import { LinkList } from "../list/link-list";
-import { PrimaryButton } from "../button";
+import { Button } from "../button";
 
 interface FooterLogoProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -47,11 +47,11 @@ export const FooterButtonLink = forwardRef<HTMLAnchorElement, FooterButtonLinkPr
   ({ children, className, asChild, ...rest }, ref) => {
     const Component = asChild ? Slot : "a";
     return (
-      <PrimaryButton asChild fill="outline" className={clsx(className as undefined)}>
+      <Button asChild variant="primary-outline" className={clsx(className as undefined)}>
         <Component ref={ref} {...rest}>
           {children}
         </Component>
-      </PrimaryButton>
+      </Button>
     );
   },
 );

--- a/packages/react/src/form/input/input.stories.tsx
+++ b/packages/react/src/form/input/input.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies -- storybook story */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
-import { PrimaryButton, SecondaryButton } from "../../button";
+import { Button } from "../../button";
 import { HStack, VStack } from "../../layout";
 import { Input } from ".";
 
@@ -118,7 +118,7 @@ export const TrackingNumberSearch: Story = {
       }}
     >
       <Input label="Sporingsnummer" style={{ width: "100%" }} />
-      <PrimaryButton size="large">Spor</PrimaryButton>
+      <Button size="large">Spor</Button>
     </HStack>
   ),
 };
@@ -148,16 +148,16 @@ export const FormWithErrorsOnSubmit: Story = {
           <Input errorMessage={errors.Two} label="Two" name="Two" />
           <Input errorMessage={errors.Three} label="Three" name="Three" />
           <VStack gap="4">
-            <PrimaryButton type="submit">Submit</PrimaryButton>
-            <SecondaryButton
-              fill="outline"
+            <Button type="submit">Submit</Button>
+            <Button
+              variant="secondary-outline"
               onClick={() => {
                 setErrors({});
               }}
               type="reset"
             >
               Reset
-            </SecondaryButton>
+            </Button>
           </VStack>
         </form>
       </VStack>

--- a/packages/react/src/modal/modal.stories.tsx
+++ b/packages/react/src/modal/modal.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies -- storybook story */
 import type { Meta, StoryObj } from "@storybook/react";
 import { useRef } from "react";
-import { PrimaryButton } from "../button";
+import { Button } from "../button";
 import { Link } from "../link";
 import { Message } from "../message";
 import { StyledHtml } from "../styled-html";
@@ -24,7 +24,7 @@ export const Main = {
 
     return (
       <>
-        <PrimaryButton onClick={() => modalRef.current?.showModal()}>Open Modal</PrimaryButton>
+        <Button onClick={() => modalRef.current?.showModal()}>Open Modal</Button>
         <Modal ref={modalRef} {...args}>
           <Modal.Header>Dialog header</Modal.Header>
           <Modal.Content>
@@ -35,10 +35,10 @@ export const Main = {
           </Modal.Content>
           <Modal.Footer>
             <HStack gap="16" wrap>
-              <PrimaryButton onClick={onMainAction}>Main action</PrimaryButton>
-              <PrimaryButton fill="outline" onClick={onClose}>
+              <Button onClick={onMainAction}>Main action</Button>
+              <Button variant="primary-outline" onClick={onClose}>
                 Cancel
-              </PrimaryButton>
+              </Button>
             </HStack>
           </Modal.Footer>
         </Modal>
@@ -53,7 +53,7 @@ export const ShareParcelModal = {
     const open = window.location.search.includes("viewMode=story");
     return (
       <>
-        <PrimaryButton onClick={() => modalRef.current?.showModal()}>Open Modal</PrimaryButton>
+        <Button onClick={() => modalRef.current?.showModal()}>Open Modal</Button>
         <Modal ref={modalRef} {...args} closeOnBackdropClick open={open}>
           <Modal.Header>Legg til pakken</Modal.Header>
           <Modal.Content>
@@ -67,7 +67,7 @@ export const ShareParcelModal = {
             </StyledHtml>
           </Modal.Content>
           <Modal.Footer>
-            <PrimaryButton fullWidth="mobile">Legg til pakken i Posten-appen </PrimaryButton>
+            <Button fullWidth="mobile">Legg til pakken i Posten-appen </Button>
           </Modal.Footer>
         </Modal>
       </>
@@ -136,9 +136,9 @@ export const AsAReadMore: Story = {
           </Modal.Content>
 
           <Modal.Footer>
-            <PrimaryButton fullWidth="mobile" onClick={() => modalRef.current?.close()}>
+            <Button fullWidth="mobile" onClick={() => modalRef.current?.close()}>
               Lukk
-            </PrimaryButton>
+            </Button>
           </Modal.Footer>
         </Modal>
       </>

--- a/packages/react/src/modal/modal.tsx
+++ b/packages/react/src/modal/modal.tsx
@@ -96,7 +96,7 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDialogElement> {
  *
  *   return (
  *     <>
- *       <PrimaryButton onClick={() => modalRef.current?.showModal()}>Open Modal</PrimaryButton>
+ *       <Button onClick={() => modalRef.current?.showModal()}>Open Modal</Button>
  *       <Modal ref={modalRef}>
  *         <Modal.Header>Dialog header</Modal.Header>
  *         <Modal.Content>
@@ -107,10 +107,10 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDialogElement> {
  *         </Modal.Content>
  *         <Modal.Footer>
  *           <HStack gap="16" wrap>
- *             <PrimaryButton onClick={onMainAction}>Main action</PrimaryButton>
- *             <PrimaryButton fill="outline" onClick={onClose}>
+ *             <Button onClick={onMainAction}>Main action</Button>
+ *             <Button variant="primary-outline" onClick={onClose}>
  *               Cancel
- *             </PrimaryButton>
+ *             </Button>
  *           </HStack>
  *         </Modal.Footer>
  *       </Modal>

--- a/packages/react/src/show-more/index.ts
+++ b/packages/react/src/show-more/index.ts
@@ -1,5 +1,2 @@
-export { AutoAnimateHeight } from "../utils/auto-animate-height";
-export type * from "../utils/auto-animate-height";
-
 export { ShowMoreButton } from "./show-more";
 export type * from "./show-more";

--- a/packages/react/src/skeleton/skeleton.stories.tsx
+++ b/packages/react/src/skeleton/skeleton.stories.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import { StyledHtml } from "../styled-html";
 import { Card } from "../card";
 import { CardStory } from "../card/card.stories";
-import { PrimaryButton } from "../button";
+import { Button } from "../button";
 import { HStack, VStack } from "../layout";
 import { Skeleton } from ".";
 
@@ -91,14 +91,14 @@ export const LoadingCards: Story = {
     const card = isLoading ? skeletonCard : realCard;
     return (
       <div>
-        <PrimaryButton
+        <Button
           size="small"
           onClick={() => {
             setIsLoading(true);
           }}
         >
           Reload
-        </PrimaryButton>
+        </Button>
         <p className="hds-mt-8">Only use greytones, never any red or green colors.</p>
         <HStack className="hds-mt-16" wrap gap="24">
           {card}


### PR DESCRIPTION
As agreed today's status meeting.

Not touching `OrderedList` and `UnorderedList`. These are semantically different html tags (`ol` and `ul`), same goes for `DescriptionList` (`dl`)

For the `Stack` component, we make an exception as those are composition components where the prefix makes more sense (`HStack` and `VStack`)