### PR TITLE
Badge dark variant name change

### DIFF
--- a/apps/examples/app/examples/badge/darker.tsx
+++ b/apps/examples/app/examples/badge/darker.tsx
@@ -4,8 +4,8 @@ import { Badge, HStack } from "@postenbring/hedwig-react";
 function Example() {
   return (
     <HStack gap="8" align="end">
-      <Badge variant="dark">Dark</Badge>
-      <Badge variant="dark" size="smaller">
+      <Badge variant="darker">Darker</Badge>
+      <Badge variant="darker" size="smaller">
         Dark
       </Badge>
     </HStack>
@@ -16,5 +16,5 @@ export default Example;
 
 import type { ExampleConfig } from "..";
 export const config: ExampleConfig = {
-  index: 1,
+  index: 6,
 };

--- a/apps/examples/app/examples/badge/darker.tsx
+++ b/apps/examples/app/examples/badge/darker.tsx
@@ -16,5 +16,5 @@ export default Example;
 
 import type { ExampleConfig } from "..";
 export const config: ExampleConfig = {
-  index: 6,
+  index: 1,
 };

--- a/apps/examples/app/examples/badge/darker.tsx
+++ b/apps/examples/app/examples/badge/darker.tsx
@@ -6,7 +6,7 @@ function Example() {
     <HStack gap="8" align="end">
       <Badge variant="darker">Darker</Badge>
       <Badge variant="darker" size="smaller">
-        Dark
+        Darker
       </Badge>
     </HStack>
   );

--- a/packages/css/src/badge/badge.css
+++ b/packages/css/src/badge/badge.css
@@ -35,7 +35,7 @@
     color: var(--hds-colors-dark);
   }
 
-  &.hds-badge--dark {
+  &.hds-badge--darker {
     background-color: var(--hds-colors-darker);
     color: var(--hds-ui-colors-white);
   }

--- a/packages/react/src/badge/badge.stories.tsx
+++ b/packages/react/src/badge/badge.stories.tsx
@@ -19,10 +19,10 @@ export const Lighter: Story = {
   },
 };
 
-export const Dark: Story = {
+export const Darker: Story = {
   args: {
-    variant: "dark",
-    children: "Dark badge",
+    variant: "darker",
+    children: "Darker badge",
   },
 };
 

--- a/packages/react/src/badge/badge.tsx
+++ b/packages/react/src/badge/badge.tsx
@@ -10,7 +10,7 @@ export interface BadgeProps extends React.AnchorHTMLAttributes<HTMLSpanElement> 
    *
    * @default "lighter"
    */
-  variant?: "lighter" | "dark" | "white" | "warning";
+  variant?: "lighter" | "darker" | "white" | "warning";
 
   /**
    * Font size of the badge
@@ -31,7 +31,7 @@ export interface BadgeProps extends React.AnchorHTMLAttributes<HTMLSpanElement> 
  * Badges are used to label, categorize or organize items using keywords to describe them.
  *
  * @example
- * <Badge variant="dark">Dark</Badge>
+ * <Badge variant="darker">Darker</Badge>
  */
 export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
   ({ children, asChild, variant = "lighter", size = "small", className, ...rest }, ref) => {


### PR DESCRIPTION
The color is Darker so it makes sense to call the variant the same. And not "Dark" which is also a name for another color