### PR TITLE
:lipstick: make headings smaller on styled-html small size

### DIFF
--- a/.changeset/weak-jars-melt.md
+++ b/.changeset/weak-jars-melt.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-css": patch
+---
+
+:lipstick: make headings smaller on styled-html small size

--- a/packages/css/src/styled-html/styled-html.css
+++ b/packages/css/src/styled-html/styled-html.css
@@ -132,6 +132,28 @@
       @extend url("./src/table/table.css:hds-table--compressed");
     }
 
+    h1 {
+      font-size: var(--hds-font-size-h1-min);
+      line-height: var(--hds-line-height-h1-min);
+    }
+
+    h2 {
+      font-size: var(--hds-font-size-h2-min);
+      line-height: var(--hds-line-height-h2-min);
+    }
+
+    h3 {
+      font-size: var(--hds-font-size-h3-min);
+      line-height: var(--hds-line-height-h3-min);
+    }
+
+    h4,
+    h5,
+    h6 {
+      font-size: var(--hds-font-size-body-title-min);
+      line-height: var(--hds-line-height-body-title-min);
+    }
+
     & p,
     & li,
     & a {


### PR DESCRIPTION
Is there any reason keep the bigger headings when the rest of texts become smaller?

Here I just use the `min` version of the fluid font size to make the headings smaller

| Default | Small before | Small after |
|--------|--------|--------|
| ![image](https://github.com/bring/hedwig-design-system/assets/244257/a3a77906-ad66-4e3b-b4bf-0bd0d8981d28) | ![image](https://github.com/bring/hedwig-design-system/assets/244257/c5677197-f40b-4ce4-954a-7112de11258c) | ![image](https://github.com/bring/hedwig-design-system/assets/244257/9a8a5ac2-3107-4139-993c-418abb5349cf) | 



