### PR TITLE
:lipstick: link-list: bump space between link list items to 16px to closer resemble hedwig legacy

### DIFF
--- a/.changeset/hot-kiwis-serve.md
+++ b/.changeset/hot-kiwis-serve.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-css": patch
+---
+
+:lipstick: link-list: bump space between link list items to 16px to closer resemble hedwig legacy

--- a/packages/css/src/list/list.css
+++ b/packages/css/src/list/list.css
@@ -90,7 +90,7 @@
     padding-left: 0;
 
     * + * {
-      margin-top: var(--hds-spacing-12);
+      margin-top: var(--hds-spacing-16);
     }
 
     & li {


### PR DESCRIPTION
@postenthinh and I discussed this. Hedwig legacy was using a line-height of 1.7 for link list items. Thus making the gaps bigger, but also the gaps when a line broke bigger.