### PR TITLE
✨ Include support for info messages

### DIFF
--- a/.changeset/big-pots-jump.md
+++ b/.changeset/big-pots-jump.md
@@ -1,0 +1,6 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+✨ Added support for new message type info

--- a/apps/examples/app/examples/message/info.tsx
+++ b/apps/examples/app/examples/message/info.tsx
@@ -1,0 +1,16 @@
+import "@postenbring/hedwig-css";
+import { Message } from "@postenbring/hedwig-react";
+
+function Example() {
+  return (
+    <Message variant="info">
+      <Message.Title>Information message</Message.Title>
+      <Message.Description>Some not that important information message.</Message.Description>
+    </Message>
+  );
+}
+
+export default Example;
+
+import type { ExampleConfig } from "..";
+export const config: ExampleConfig = {};

--- a/packages/css/src/message/message.css
+++ b/packages/css/src/message/message.css
@@ -52,6 +52,15 @@
     }
   }
 
+  &.hds-message--info {
+    background-color: var(--hds-ui-colors-light-grey-fill);
+
+    &::before {
+      background-size: 32px;
+      background-image: var(--_hds-info-square);
+    }
+  }
+
   &.hds-message--neutral {
     background-color: var(--hds-ui-colors-light-grey-fill);
 

--- a/packages/react/src/message/message.stories.tsx
+++ b/packages/react/src/message/message.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof Message> = {
 
   argTypes: {
     variant: {
-      options: ["success", "attention", "warning", "neutral"],
+      options: ["success", "attention", "warning", "neutral", "info"],
       control: {
         type: "radio",
       },

--- a/packages/react/src/message/message.tsx
+++ b/packages/react/src/message/message.tsx
@@ -49,7 +49,7 @@ MessageDescription.displayName = "Message.Description";
 
 export type MessageProps = (
   | {
-      variant?: "success" | "attention" | "warning";
+      variant?: "success" | "attention" | "warning" | "info";
       icon?: never;
       iconClassName?: never;
     }


### PR DESCRIPTION
# Details

There have been a few discussion internally in regards to how a message with type info should look like - meaning which sort of icons to use, and how it should look like.

In our team we've now had multiple discussions regarding this, hence we're now just using whatever we have defined in Figma and adding this as a separate element - in order to avoid discussions in the future regarding the "how should this look like".
Also, if it changes, it is now centrally contained 😅.

# Example

```jsx
    <Message variant="info">
      <Message.Title>Information message</Message.Title>
      <Message.Description>Some not that important information message.</Message.Description>
    </Message>
```

![Skjermbilde 2024-09-18 kl  12 35 25](https://github.com/user-attachments/assets/100194a0-95e1-4372-b103-154ccd1cfbcb)
