### PR TITLE
Remove conditional rendering of error message in checkbox

### DIFF
--- a/.changeset/fluffy-tools-hide.md
+++ b/.changeset/fluffy-tools-hide.md
@@ -1,0 +1,7 @@
+---
+"@postenbring/hedwig-react": patch
+---
+
+:bug: Fix screen readers not picking up `Checkbox` error messages due to conditional rendering
+
+the `aria-live` attribute requires that the element exists in the DOM already for it to announce changes

--- a/packages/react/src/form/checkbox/checkbox.tsx
+++ b/packages/react/src/form/checkbox/checkbox.tsx
@@ -74,7 +74,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           </label>
           {title ? children : null}
         </div>
-        {errorMessage ? <ErrorMessage id={errorMessageId}>{errorMessage}</ErrorMessage> : null}
+        <ErrorMessage id={errorMessageId}>{errorMessage}</ErrorMessage>
       </div>
     );
   },


### PR DESCRIPTION
Conditional rendering causes the error message to not be announced when it shows up. This has been fixed in the Input and RadioButton component, but not here - until now :)