### PR TITLE
Update accordion-content.tsx

### DIFF
--- a/packages/react/src/accordion/accordion-content.tsx
+++ b/packages/react/src/accordion/accordion-content.tsx
@@ -16,7 +16,6 @@ export const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps
     return (
       <div
         id={context.contentId}
-        aria-hidden={!context.open}
         data-state={context.open ? "open" : "closed"}
         {...{ inert: context.open ? undefined : "true" }}
         className={clsx("hds-accordion-item-content", className as undefined)}


### PR DESCRIPTION
aria-hidden is not needed. Screen readers skips because of aria-expanded anyway. And WCAG doesn't like hidden links: https://rocketvalidator.com/accessibility-validation/axe/4.6/aria-hidden-focus