### PR TITLE
Error-summary: Use link `solid` variant and matching black bullet points

### DIFF
--- a/.changeset/curvy-bears-press.md
+++ b/.changeset/curvy-bears-press.md
@@ -1,0 +1,8 @@
+---
+"@postenbring/hedwig-react": minor
+"@postenbring/hedwig-css": minor
+---
+
+allow list to have the bullet point (marker) color changed
+
+needed by the error-summary component

--- a/packages/css/src/list/list.css
+++ b/packages/css/src/list/list.css
@@ -4,6 +4,8 @@
 }
 
 .hds-list {
+  --_hds-list-marker-color: var(--hds-colors-dark);
+
   /**
    * Spacing from the left
    * In hedwig legacy the bullets started at the content
@@ -15,7 +17,7 @@
     padding-left: var(--hds-spacing-8);
 
     &::marker {
-      color: var(--hds-colors-dark);
+      color: var(--_hds-list-marker-color);
     }
   }
 

--- a/packages/react/src/form/error-summary/error-summary.tsx
+++ b/packages/react/src/form/error-summary/error-summary.tsx
@@ -108,7 +108,7 @@ export const ErrorSummaryItem = forwardRef<HTMLLIElement, ErrorSummaryItemProps>
 
     return (
       <li ref={ref} {...rest}>
-        <Link size="small" href={href} {...linkProps} onClick={onClick}>
+        <Link size="small" href={href} variant="solid" {...linkProps} onClick={onClick}>
           {children}
         </Link>
       </li>

--- a/packages/react/src/form/error-summary/error-summary.tsx
+++ b/packages/react/src/form/error-summary/error-summary.tsx
@@ -70,10 +70,15 @@ export interface ErrorSummaryListProps extends ListProps {
   size?: ListProps["size"];
 }
 export const ErrorSummaryList = forwardRef<HTMLUListElement, ErrorSummaryListProps>(
-  ({ children, size = "small", ...rest }, ref) => {
+  ({ children, style: _style, size = "small", ...rest }, ref) => {
+    const style = {
+      // Match the link `solid` style, which black underline
+      "--_hds-list-marker-color": "var(--hds-ui-colors-black)",
+      ..._style,
+    };
     return (
       <Message.Description asChild>
-        <UnorderedList size={size} ref={ref} {...rest}>
+        <UnorderedList size={size} ref={ref} style={style} {...rest}>
           {children}
         </UnorderedList>
       </Message.Description>


### PR DESCRIPTION
Ref. slack: https://posten.slack.com/archives/C4U4PR0A2/p1730733569538909?thread_ts=1730382966.771939&cid=C4U4PR0A2

> The red unline doesn't validate with the yellow background (2.64:1)

| Before | After |
|--------|--------|
| <img width="599" alt="image" src="https://github.com/user-attachments/assets/fe0dbf04-5f1d-4410-8d6a-115e22bea500"> | <img width="626" alt="image" src="https://github.com/user-attachments/assets/072d15ff-fea8-4da4-a534-df8e91bcdbbc"> | 
