### PR TITLE
:lipstick: checkbox/radio-button: only show focus outline on focus-visible

### DIFF
--- a/.changeset/large-donuts-jog.md
+++ b/.changeset/large-donuts-jog.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-css": patch
+---
+
+:lipstick: checkbox/radio-button: only show focus outline on focus-visible

--- a/packages/css/src/form/checkbox/checkbox.css
+++ b/packages/css/src/form/checkbox/checkbox.css
@@ -128,7 +128,7 @@
   }
 
   /* Focus effect */
-  &:focus-within {
+  &:has(input[type="checkbox"]:focus-visible) {
     outline: 2px solid var(--hds-colors-dark);
     outline-offset: 2px;
   }

--- a/packages/css/src/form/radio-button/radio-button.css
+++ b/packages/css/src/form/radio-button/radio-button.css
@@ -130,7 +130,7 @@
   }
 
   /* Focus effect */
-  &:focus-within {
+  &:has(input[type="radio"]:focus-visible) {
     outline: 2px solid var(--hds-colors-dark);
     outline-offset: 2px;
   }


### PR DESCRIPTION
I think it's a litte annoying that the whole checkbox/radio-button is outlined when I click it.
This PR makes it so that it's only outlined when select with a keyboard

<img width="559" alt="image" src="https://github.com/user-attachments/assets/5158b700-9f47-417c-af7b-009f2f1c5662">


Same as Digdir does it: https://next.storybook.designsystemet.no/?path=/docs/komponenter-checkbox--docs