### PR TITLE
:children_crossing: Allow for React 19+ to be ussed as peer dep

### DIFF
--- a/.changeset/tough-clouds-pump.md
+++ b/.changeset/tough-clouds-pump.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-react": patch
+---
+
+Allow for React 19 as peer dependency

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,10 +34,10 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@types/react": "^17.0.0 || ^18.0.0",
-    "@types/react-dom": "^17.0.0 || ^18.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@postenbring/hedwig-css": "workspace:*",


### PR DESCRIPTION
# Details

In order to let HDS users have a soft-launch of the features React 19+ brings without being the source of hindering, we allow for React 19 to be defined as a dependency. However, support is not quite there yet, so some bugs could occur.

Tested through one of our apps, and no bugs found thus far - though, not all components are currently being used, so take that statement with a grain of salt 🧂 .