### PR TITLE
Support use of Breadcrumbs without reset.css

### DIFF
--- a/.changeset/pink-coins-enjoy.md
+++ b/.changeset/pink-coins-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-css": patch
+---
+
+Support use of Breadcrumbs without reset.css

--- a/apps/examples/app/examples/breadcrumbs/without-body-or-reset-css.tsx
+++ b/apps/examples/app/examples/breadcrumbs/without-body-or-reset-css.tsx
@@ -1,0 +1,36 @@
+import "@postenbring/hedwig-css/dist/tokens.css";
+import "@postenbring/hedwig-css/dist/fonts.css";
+
+import "@postenbring/hedwig-css/dist/breadcrumbs.css";
+import "@postenbring/hedwig-css/dist/link.css";
+
+import { Breadcrumbs, Link } from "@postenbring/hedwig-react";
+
+function Example() {
+  return (
+    <>
+      <Breadcrumbs>
+        <li>
+          <Link href="https://www.posten.no">Track letters and parcels</Link>
+        </li>
+        <li>Shipment from SOMEONE YOU KNOW</li>
+      </Breadcrumbs>
+
+      {/* Just for example sake, since the white background comes from `body.css` */}
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `body { background-color: var(--hds-ui-colors-white); }`,
+        }}
+      />
+    </>
+  );
+}
+
+export default Example;
+
+import type { ExampleConfig } from "..";
+export const config: ExampleConfig = {
+  index: 2,
+  breakpointIndicator: "top",
+  description: "When just importing the bare minimum css required.",
+};

--- a/packages/css/src/breadcrumbs/breadcrumbs.css
+++ b/packages/css/src/breadcrumbs/breadcrumbs.css
@@ -16,6 +16,8 @@
   }
 
   & li {
+    display: flex;
+
     /*
      * Design in Figma has an extra 2px distance between
      * the text and underline border on links
@@ -36,6 +38,7 @@
     }
 
     &::before {
+      content: "";
       display: inline-block;
       background-image: var(--_hds-icons-cheveron-right-dark-grey);
       width: 20px;


### PR DESCRIPTION
Prior to the change, when using Breadcrumbs without reset.css, the chevron icon between the links was not displayed.

The reset stylesheet contains a `content: ""` rule which is applied to the `<li>` elements, and this leads to the icon being shown. We've just added the same rule to breadcrumbs.css, and altered the display rule to align the links and icons in the list items.

The rule from reset.css (sanitize.css):
https://github.com/csstools/sanitize.css/blob/61c85b6961f684d0124093d97475073bb08f557e/sanitize.css#L102-L105