### PR TITLE
Fullwidth card responsive

### DIFF
--- a/.changeset/recursive-name-recurses.md
+++ b/.changeset/recursive-name-recurses.md
@@ -1,0 +1,6 @@
+---
+"@postenbring/hedwig-css": patch
+"@postenbring/hedwig-react": patch
+---
+
+Fullwidth-card: re-styled for responsive layout. Keeps layout and images nice regardless of their size or aspect ratio, or the length of the text next to them. Square source images are recommended.

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ storybook-static/
 .stylelintcache
 **/tsconfig.tsbuildinfo
 .tsup
+vite.config.ts.timestamp-*

--- a/apps/examples/app/examples/card/full-width.tsx
+++ b/apps/examples/app/examples/card/full-width.tsx
@@ -39,7 +39,13 @@ function Example() {
           </Card.Body>
         </Card>
         <h2>Color - Lighter Brand - Default - Image right</h2>
-        <Card variant="full-width" color="lighter-brand">
+        <Card variant="full-width" color="lighter-brand" imageRight>
+          <Card.Media>
+            <Card.MediaImg
+              alt="Posten delivery van with Bring cargo truck in the background"
+              src={postenBringImage}
+            />
+          </Card.Media>
           <Card.Body>
             <Card.BodyHeader as="h2">
               <Card.BodyHeaderOverline>Importing goods</Card.BodyHeaderOverline>
@@ -58,12 +64,6 @@ function Example() {
               </Link>
             </Card.BodyAction>
           </Card.Body>
-          <Card.Media>
-            <Card.MediaImg
-              alt="Posten delivery van with Bring cargo truck in the background"
-              src={postenBringImage}
-            />
-          </Card.Media>
         </Card>
         <h2>Color - Light Grey Fill</h2>
         <Card variant="full-width" color="light-grey-fill">

--- a/apps/examples/app/examples/card/full-width.tsx
+++ b/apps/examples/app/examples/card/full-width.tsx
@@ -149,21 +149,7 @@ function Example() {
               <Card.BodyAction asChild>
                 <Button fullWidth="mobile" variant="primary-outline" asChild>
                   <a href="https://www.posten.no" target="_blank" rel="noreferrer">
-                    Pr. outline
-                  </a>
-                </Button>
-              </Card.BodyAction>
-              <Card.BodyAction asChild>
-                <Button fullWidth="mobile" variant="secondary" asChild>
-                  <a href="https://www.posten.no" target="_blank" rel="noreferrer">
-                    Secondary
-                  </a>
-                </Button>
-              </Card.BodyAction>
-              <Card.BodyAction asChild>
-                <Button fullWidth="mobile" variant="secondary-outline" asChild>
-                  <a href="https://www.posten.no" target="_blank" rel="noreferrer">
-                    Sec. outline
+                    Primary outline
                   </a>
                 </Button>
               </Card.BodyAction>

--- a/apps/examples/app/examples/card/full-width.tsx
+++ b/apps/examples/app/examples/card/full-width.tsx
@@ -1,5 +1,5 @@
 import "@postenbring/hedwig-css";
-import { Card, Link, Container, HStack, Button } from "@postenbring/hedwig-react";
+import { Card, Link, Container, Button } from "@postenbring/hedwig-react";
 import postenBringImage from "../../assets/posten-bring.avif";
 
 function Example() {
@@ -138,22 +138,36 @@ function Example() {
               abroad. The new rules largely mean that foreign online shops will collect the value
               added tax (VAT) immediately when you shop and pay for the goods.
             </Card.BodyDescription>
-            <HStack wrap>
+            <Card.BodyActionRow>
               <Card.BodyAction asChild>
                 <Button fullWidth="mobile" asChild>
                   <a href="https://www.postenbring.no" target="_blank" rel="noreferrer">
-                    Postenbring
+                    Primary
                   </a>
                 </Button>
               </Card.BodyAction>
               <Card.BodyAction asChild>
                 <Button fullWidth="mobile" variant="primary-outline" asChild>
                   <a href="https://www.posten.no" target="_blank" rel="noreferrer">
-                    Posten
+                    Pr. outline
                   </a>
                 </Button>
               </Card.BodyAction>
-            </HStack>
+              <Card.BodyAction asChild>
+                <Button fullWidth="mobile" variant="secondary" asChild>
+                  <a href="https://www.posten.no" target="_blank" rel="noreferrer">
+                    Secondary
+                  </a>
+                </Button>
+              </Card.BodyAction>
+              <Card.BodyAction asChild>
+                <Button fullWidth="mobile" variant="secondary-outline" asChild>
+                  <a href="https://www.posten.no" target="_blank" rel="noreferrer">
+                    Sec. outline
+                  </a>
+                </Button>
+              </Card.BodyAction>
+            </Card.BodyActionRow>
           </Card.Body>
         </Card>
       </div>

--- a/apps/examples/app/examples/card/full-width.tsx
+++ b/apps/examples/app/examples/card/full-width.tsx
@@ -1,5 +1,5 @@
 import "@postenbring/hedwig-css";
-import { Card, Link, Container } from "@postenbring/hedwig-react";
+import { Card, Link, Container, HStack, Button } from "@postenbring/hedwig-react";
 import postenBringImage from "../../assets/posten-bring.avif";
 
 function Example() {
@@ -117,6 +117,43 @@ function Example() {
                 Import duty changes from 2024
               </Link>
             </Card.BodyAction>
+          </Card.Body>
+        </Card>
+        <h2>CTA Buttons</h2>
+        <Card variant="full-width" color="lighter-brand">
+          <Card.Media>
+            <Card.MediaImg
+              alt="Posten delivery van with Bring cargo truck in the background"
+              src={postenBringImage}
+            />
+          </Card.Media>
+          <Card.Body>
+            <Card.BodyHeader as="h2">
+              <Card.BodyHeaderOverline>Importing goods</Card.BodyHeaderOverline>
+              <Card.BodyHeaderTitle>Import duties</Card.BodyHeaderTitle>
+            </Card.BodyHeader>
+            <Card.BodyDescription>
+              From January 1, 2024, the authorities will abolish the 350-kroner limit. This means
+              that you have to pay import duties from the first krone on most of what you buy from
+              abroad. The new rules largely mean that foreign online shops will collect the value
+              added tax (VAT) immediately when you shop and pay for the goods.
+            </Card.BodyDescription>
+            <HStack wrap>
+              <Card.BodyAction asChild>
+                <Button fullWidth="mobile" asChild>
+                  <a href="https://www.postenbring.no" target="_blank" rel="noreferrer">
+                    Postenbring
+                  </a>
+                </Button>
+              </Card.BodyAction>
+              <Card.BodyAction asChild>
+                <Button fullWidth="mobile" variant="primary-outline" asChild>
+                  <a href="https://www.posten.no" target="_blank" rel="noreferrer">
+                    Posten
+                  </a>
+                </Button>
+              </Card.BodyAction>
+            </HStack>
           </Card.Body>
         </Card>
       </div>

--- a/apps/examples/app/examples/card/full-width.tsx
+++ b/apps/examples/app/examples/card/full-width.tsx
@@ -39,7 +39,7 @@ function Example() {
           </Card.Body>
         </Card>
         <h2>Color - Lighter Brand - Default - Image right</h2>
-        <Card variant="full-width" color="lighter-brand" imageRight>
+        <Card variant="full-width" color="lighter-brand" imagePosition="right">
           <Card.Media>
             <Card.MediaImg
               alt="Posten delivery van with Bring cargo truck in the background"

--- a/packages/css/src/_custom-media.css
+++ b/packages/css/src/_custom-media.css
@@ -18,12 +18,3 @@
 @custom-media --before-medium (width < 720px);
 @custom-media --before-large (width < 940px);
 @custom-media --before-xlarge (width < 1200px);
-
-/*  Extra customized for edge cases: */
-
-/* Used in packages/css/src/card/fullwidth-card.css: */
-@custom-media --fullwidthcard-media-narrowest (width < 308px);
-@custom-media --fullwidthcard-media-narrow (width >= 308px) and (width < 412px);
-@custom-media --fullwidthcard-media-mid (width >= 412px) and (width < 648px);
-@custom-media --fullwidthcard-media-large (width >= 648px) and (width < 800px);
-@custom-media --fullwidthcard-largest (width >= 800px);

--- a/packages/css/src/_custom-media.css
+++ b/packages/css/src/_custom-media.css
@@ -18,3 +18,12 @@
 @custom-media --before-medium (width < 720px);
 @custom-media --before-large (width < 940px);
 @custom-media --before-xlarge (width < 1200px);
+
+/*  Extra customized for edge cases: */
+
+/* Used in packages/css/src/card/fullwidth-card.css: */
+@custom-media --fullwidthcard-media-narrowest (width < 308px);
+@custom-media --fullwidthcard-media-narrow (width >= 308px) and (width < 412px);
+@custom-media --fullwidthcard-media-mid (width >= 412px) and (width < 648px);
+@custom-media --fullwidthcard-media-large (width >= 648px) and (width < 800px);
+@custom-media --fullwidthcard-largest (width >= 800px);

--- a/packages/css/src/card/card.css
+++ b/packages/css/src/card/card.css
@@ -1,6 +1,7 @@
 @import url("../_custom-media.css");
 @import url("../_icons.css");
 @import url("../spacing/spacing.css");
+@import url("./fullwidth-card.css");
 
 /* stylelint-disable selector-class-pattern */
 .hds-card {
@@ -25,7 +26,7 @@
     margin-bottom: var(--hds-spacing-12-16);
   }
 
-  .hds-card__media__img {
+  .hds-card__media--img {
     width: 100%;
     height: 100%;
     object-fit: cover;
@@ -120,8 +121,7 @@
   background-color: var(--hds-colors-darker);
 }
 
-.hds-card--focus,
-.hds-card--full-width {
+.hds-card--focus {
   max-width: none;
   display: grid;
   grid-template-rows: 1fr 1fr;
@@ -143,7 +143,7 @@
     }
   }
 
-  .hds-card__media__img {
+  .hds-card__media--img {
     width: 100%;
     height: 100%;
     object-fit: cover;
@@ -162,9 +162,7 @@
   .hds-card__body-action {
     margin-top: var(--hds-spacing-20-24);
   }
-}
 
-.hds-card--focus {
   .hds-card__body-header-overline {
     color: var(--hds-colors-light);
   }

--- a/packages/css/src/card/card.css
+++ b/packages/css/src/card/card.css
@@ -26,7 +26,7 @@
     margin-bottom: var(--hds-spacing-12-16);
   }
 
-  .hds-card__media--img {
+  .hds-card__media__img {
     width: 100%;
     height: 100%;
     object-fit: cover;
@@ -143,7 +143,7 @@
     }
   }
 
-  .hds-card__media--img {
+  .hds-card__media__img {
     width: 100%;
     height: 100%;
     object-fit: cover;

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -1,3 +1,4 @@
+@import url("../_custom-media.css");
 @import url("../spacing/spacing.css");
 
 :root {
@@ -9,13 +10,13 @@
   --fullwidthcard-image-aspect-mini: 100 / 155;
   --fullwidthcard-image-height-max: 420px;
 
-  @media (width >= 800px) {
+  @media (--fullwidthcard-largest) {
     --fullwidthcard-image-height-max: 650px;
   }
 
   --fullwidthcard-image-height-fixed: 300px;
 
-  @media (width >= 500px) {
+  @media (--fullwidthcard-media-large) {
     --fullwidthcard-image-height-fixed: 600px;
   }
 }
@@ -43,22 +44,22 @@
 		*/
 
     /* Narrowest: fixed aspect ratio (portrait: height is 1.5 times the width). */
-    @media (width <= 307px) {
+    @media (--fullwidthcard-media-narrowest) {
       aspect-ratio: var(--fullwidthcard-image-aspect-mini);
     }
 
     /* Second narrowest: fixed image height */
-    @media (width >= 308px) and (width <= 411px) {
+    @media (--fullwidthcard-media-narrow) {
       height: var(--fullwidthcard-image-height-fixed);
     }
 
     /* Middle narrow: fixed aspect ratio (quare format), variable height */
-    @media (width >= 412px) and (width <= 647px) {
+    @media (--fullwidthcard-media-mid) {
       aspect-ratio: 1;
     }
 
     /* "Widest" narrow card layout: fixed image height (but higher now) */
-    @media (width >= 648px) and (width <= 799px) {
+    @media (--fullwidthcard-media-large) {
       height: var(--fullwidthcard-image-height-fixed);
     }
   }
@@ -72,7 +73,7 @@
 	Image height is at least 400px high, but scales up if the body text is higher.
 	Image has a max height if the text is huge, limiting the aspect ratio of the image.
  */
-@media (width >= 800px) {
+@media (--fullwidthcard-largest) {
   .hds-card.hds-card--full-width {
     display: flex;
     flex-direction: row;

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -65,6 +65,10 @@
       margin-top: var(--hds-spacing-20-24);
     }
 
+    .hds-stack {
+      gap: 8px;
+    }
+
     .hds-card__body-action {
       margin-top: var(--hds-spacing-20-24);
     }

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -65,8 +65,11 @@
       margin-top: var(--hds-spacing-20-24);
     }
 
-    .hds-stack {
-      gap: 8px;
+    .hds-card__body-action-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--hds-spacing-16);
+      margin-top: var(--hds-spacing-20-24);
     }
 
     .hds-card__body-action {
@@ -74,7 +77,7 @@
     }
 
     .hds-button {
-      margin-top: var(--hds-spacing-20-24);
+      margin-top: 0;
     }
   }
 

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -68,16 +68,22 @@
     .hds-card__body-action-row {
       display: flex;
       flex-wrap: wrap;
-      gap: var(--hds-spacing-16);
+      gap: var(--hds-spacing-8);
       margin-top: var(--hds-spacing-20-24);
+
+      .hds-button {
+        border-radius: var(--hds-border-radius-8);
+        flex: 1 0 160px;
+        white-space: nowrap;
+      }
     }
 
     .hds-card__body-action {
-      margin-top: var(--hds-spacing-20-24);
+      margin-top: 0;
     }
 
-    .hds-button {
-      margin-top: 0;
+    .hds-link.hds-card__body-action {
+      margin-top: var(--hds-spacing-20-24);
     }
   }
 

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -1,0 +1,103 @@
+@import url("../spacing/spacing.css");
+
+:root {
+  /* Basic sizing for fullwidth cards: */
+  --fullwidthcard-min-height: 400px;
+  --fullwidthcard-content-min-height: calc(
+    var(--fullwidthcard-min-height) - 2 * var(--hds-spacing-20-24)
+  );
+  --fullwidthcard-image-aspect-mini: 100 / 155;
+  --fullwidthcard-image-height-max: 420px;
+
+  @media (width >= 800px) {
+    --fullwidthcard-image-height-max: 650px;
+  }
+
+  --fullwidthcard-image-height-fixed: 300px;
+
+  @media (width >= 500px) {
+    --fullwidthcard-image-height-fixed: 600px;
+  }
+}
+
+.hds-card.hds-card--full-width {
+  max-width: inherit;
+
+  * {
+    box-sizing: border-box;
+  }
+
+  .hds-card__media {
+    overflow: hidden;
+    position: relative;
+    border-radius: var(--hds-border-radius-8);
+    max-height: var(--fullwidthcard-image-height-max);
+    width: 100%;
+
+    /*  Responsivity: different card layouts and content/images sizes,
+			while still displaying as much as the image as possible and trying to keep focus on the middle,
+			.hds-card__media is displayed in particular ways on particular viewport widths,
+			 but always filling the available width
+			 (which below 800px is the full width of the card minus padding,
+			 and above 800px is only half the width of the card):
+		*/
+
+    /* Narrowest: fixed aspect ratio (portrait: height is 1.5 times the width). */
+    @media (width <= 307px) {
+      aspect-ratio: var(--fullwidthcard-image-aspect-mini);
+    }
+
+    /* Second narrowest: fixed image height */
+    @media (width >= 308px) and (width <= 411px) {
+      height: var(--fullwidthcard-image-height-fixed);
+    }
+
+    /* Middle narrow: fixed aspect ratio (quare format), variable height */
+    @media (width >= 412px) and (width <= 647px) {
+      aspect-ratio: 1;
+    }
+
+    /* "Widest" narrow card layout: fixed image height (but higher now) */
+    @media (width >= 648px) and (width <= 799px) {
+      height: var(--fullwidthcard-image-height-fixed);
+    }
+  }
+
+  .hds-card__body > * {
+    margin: var(--hds-spacing-32-40);
+  }
+}
+
+/*  Wide layout: image to the left or right of the text.
+	Image height is at least 400px high, but scales up if the body text is higher.
+	Image has a max height if the text is huge, limiting the aspect ratio of the image.
+ */
+@media (width >= 800px) {
+  .hds-card.hds-card--full-width {
+    display: flex;
+    flex-direction: row;
+    gap: var(--hds-spacing-12-16);
+
+    & > .hds-card__media,
+    & > .hds-card__body {
+      flex: 1;
+      min-height: var(--fullwidthcard-content-min-height);
+    }
+
+    /* Image is absolutely positioned and centered within .hds-card__media, to avoid making .hds-card__media outgrow the body text. */
+    .hds-card__media > .hds-card__media--img {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+
+    /* Body sizes itself based on its content */
+    .hds-card__body {
+      align-self: flex-start;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+    }
+  }
+}

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -32,36 +32,31 @@
     max-height: var(--hds-fullwidthcard-image-maxheight-small);
     width: 100%;
 
-    /*  Responsivity: different card layouts and content/images sizes,
-				while still displaying as much as the image as possible and trying to keep focus on the middle,
-				.hds-card__media is displayed in particular ways on particular viewport widths,
-				 but always filling the available width
-				 (which below 800px is the full width of the card minus padding,
-				 and above 800px is only half the width of the card):
-			*/
+    /*  Responsivity: different card layouts and content/images sizes, while still displaying as much as the image as
+     *  possible and trying to keep focus on the middle, .hds-card__media is displayed in particular ways on
+     *  particular viewport widths, but always filling the available width (which below 800px is the full width of the
+     *  card minus padding, and above 800px is only half the width of the card):
+     *
+     **/
 
     /* Narrowest: fixed aspect ratio (portrait: height is 1.5 times the width). */
-    @container fullwidthcard (width < 308px) {
+    @container fullwidthcard (width < 300px) {
       aspect-ratio: var(--hds-fullwidthcard-image-aspect-mini);
-    }
-
-    /* Second narrowest: fixed image height */
-    @container fullwidthcard (width >= 308px) and (width < 412px) {
-      height: var(--hds-fullwidthcard-image-height-small);
+      max-height: var(--hds-fullwidthcard-image-height-small);
     }
 
     /* Middle narrow: fixed aspect ratio (quare format), variable height */
-    @container fullwidthcard (width >= 412px) and (width < 648px) {
+    @container fullwidthcard (width >= 300px) and (width < 648px) {
       aspect-ratio: 1;
     }
 
-    /* "Widest" narrow card layout: fixed image height (but higher now) */
+    /* "Widest" of the narrow card layouts: fixed image height (but higher now) */
     @container fullwidthcard (width >= 648px) and (width < 800px) {
       height: var(--hds-fullwidthcard-image-height-medium);
     }
   }
 
-  .hds-card__body > * {
+  .hds-card__centerbody {
     margin: var(--hds-spacing-32-40);
   }
 
@@ -73,10 +68,10 @@
     margin-top: var(--hds-spacing-20-24);
   }
 
-  /*  Wide layout: image to the left or right of the text.
-		Image height is at least 400px high, but scales up if the body text is higher.
-		Image has a max height if the text is huge, limiting the aspect ratio of the image.
-	 */
+  /*  Wide layout: image to the left or right of the text. Image height is at least 400px high, but scales up if the
+   *  body text is higher. Image has a max height if the text is huge, limiting the aspect ratio of the image.
+   *
+   **/
   @container fullwidthcard (width >= 800px) {
     .hds-card__layoutwrapper {
       display: flex;
@@ -94,8 +89,10 @@
       }
     }
 
-    /* Image is absolutely positioned within .hds-card__media,
-		   to center and avoid making .hds-card__media outgrow the body text: */
+    /* Image is absolutely positioned within .hds-card__media, to center and avoid making .hds-card__media outgrow
+     * the body text:
+     *
+     **/
 
     /* stylelint-disable selector-class-pattern */
     .hds-card__media > .hds-card__media__img {
@@ -105,7 +102,7 @@
       transform: translate(-50%, -50%);
     }
 
-    &.hds-card--imagepos-right .hds-card__media {
+    &.hds-card--image-position-right .hds-card__media {
       order: 2;
     }
 

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -87,7 +87,9 @@
 
     /* Image is absolutely positioned within .hds-card__media,
        to center and avoid making .hds-card__media outgrow the body text: */
-    .hds-card__media > .hds-card__media--img {
+
+    /* stylelint-disable selector-class-pattern */
+    .hds-card__media > .hds-card__media__img {
       position: absolute;
       top: 50%;
       left: 50%;

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -1,19 +1,17 @@
 @import url("../spacing/spacing.css");
 
-:root {
-  /* Basic sizing for fullwidth cards: */
-  --fullwidthcard-min-height: 400px;
-  --fullwidthcard-content-min-height: calc(
-    var(--fullwidthcard-min-height) - 2 * var(--hds-spacing-20-24)
-  );
-  --fullwidthcard-image-aspect-mini: 100 / 155;
-  --fullwidthcard-image-maxheight-small: 420px;
-  --fullwidthcard-image-maxheight-medium: 650px;
-  --fullwidthcard-image-height-small: 300px;
-  --fullwidthcard-image-height-medium: 600px;
-}
-
 .hds-card.hds-card--full-width {
+  /* Basic sizing for fullwidth cards: */
+  --hds-fullwidthcard-min-height: 400px;
+  --hds-fullwidthcard-content-min-height: calc(
+    var(--hds-fullwidthcard-min-height) - 2 * var(--hds-spacing-20-24)
+  );
+  --hds-fullwidthcard-image-aspect-mini: 100 / 155;
+  --hds-fullwidthcard-image-maxheight-small: 420px;
+  --hds-fullwidthcard-image-maxheight-medium: 650px;
+  --hds-fullwidthcard-image-height-small: 300px;
+  --hds-fullwidthcard-image-height-medium: 600px;
+
   max-width: inherit;
   container-type: inline-size;
   container-name: fullwidthcard;
@@ -31,7 +29,7 @@
     overflow: hidden;
     position: relative;
     border-radius: var(--hds-border-radius-8);
-    max-height: var(--fullwidthcard-image-maxheight-small);
+    max-height: var(--hds-fullwidthcard-image-maxheight-small);
     width: 100%;
 
     /*  Responsivity: different card layouts and content/images sizes,
@@ -44,12 +42,12 @@
 
     /* Narrowest: fixed aspect ratio (portrait: height is 1.5 times the width). */
     @container fullwidthcard (width < 308px) {
-      aspect-ratio: var(--fullwidthcard-image-aspect-mini);
+      aspect-ratio: var(--hds-fullwidthcard-image-aspect-mini);
     }
 
     /* Second narrowest: fixed image height */
     @container fullwidthcard (width >= 308px) and (width < 412px) {
-      height: var(--fullwidthcard-image-height-small);
+      height: var(--hds-fullwidthcard-image-height-small);
     }
 
     /* Middle narrow: fixed aspect ratio (quare format), variable height */
@@ -59,12 +57,20 @@
 
     /* "Widest" narrow card layout: fixed image height (but higher now) */
     @container fullwidthcard (width >= 648px) and (width < 800px) {
-      height: var(--fullwidthcard-image-height-medium);
+      height: var(--hds-fullwidthcard-image-height-medium);
     }
   }
 
   .hds-card__body > * {
     margin: var(--hds-spacing-32-40);
+  }
+
+  .hds-card__body-description {
+    margin-top: var(--hds-spacing-20-24);
+  }
+
+  .hds-card__body-action {
+    margin-top: var(--hds-spacing-20-24);
   }
 
   /*  Wide layout: image to the left or right of the text.
@@ -80,11 +86,11 @@
       .hds-card__media,
       .hds-card__body {
         flex: 1;
-        min-height: var(--fullwidthcard-content-min-height);
+        min-height: var(--hds-fullwidthcard-content-min-height);
       }
 
       .hds-card__media {
-        max-height: var(--fullwidthcard-image-maxheight-medium);
+        max-height: var(--hds-fullwidthcard-image-maxheight-medium);
       }
     }
 

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -22,6 +22,11 @@
     box-sizing: border-box;
   }
 
+  .hds-card__layoutwrapper {
+    height: 100%;
+    width: 100%;
+  }
+
   .hds-card__media {
     overflow: hidden;
     position: relative;
@@ -61,32 +66,32 @@
   .hds-card__body > * {
     margin: var(--hds-spacing-32-40);
   }
-}
 
-/*  Wide layout: image to the left or right of the text.
-	Image height is at least 400px high, but scales up if the body text is higher.
-	Image has a max height if the text is huge, limiting the aspect ratio of the image.
- */
+  /*  Wide layout: image to the left or right of the text.
+		Image height is at least 400px high, but scales up if the body text is higher.
+		Image has a max height if the text is huge, limiting the aspect ratio of the image.
+	 */
+  @container fullwidthcard (width >= 800px) {
+    .hds-card__layoutwrapper {
+      display: flex;
+      flex-direction: row;
+      gap: var(--hds-spacing-12-16);
 
-/* TODO: THIS IS THE CONTAINER ITSELF! HOW TO SET THIS UP WITHOUT KNOWING THE PARENT ABOVE IT? */
-@container fullwidthcard (width >= 800px) {
-  .hds-card.hds-card--full-width {
-    display: flex;
-    flex-direction: row;
-    gap: var(--hds-spacing-12-16);
-    max-height: var(--fullwidthcard-image-maxheight-medium);
+      .hds-card__media,
+      .hds-card__body {
+        flex: 1;
+        min-height: var(--fullwidthcard-content-min-height);
+      }
 
-    & > .hds-card__media,
-    & > .hds-card__body {
-      flex: 1;
-      min-height: var(--fullwidthcard-content-min-height);
+      .hds-card__media {
+        max-height: var(--fullwidthcard-image-maxheight-medium);
+      }
     }
 
     /* Image is absolutely positioned within .hds-card__media,
 		   to center and avoid making .hds-card__media outgrow the body text: */
 
     /* stylelint-disable selector-class-pattern */
-
     .hds-card__media > .hds-card__media__img {
       position: absolute;
       top: 50%;

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -1,4 +1,3 @@
-@import url("../_custom-media.css");
 @import url("../spacing/spacing.css");
 
 :root {
@@ -8,21 +7,16 @@
     var(--fullwidthcard-min-height) - 2 * var(--hds-spacing-20-24)
   );
   --fullwidthcard-image-aspect-mini: 100 / 155;
-  --fullwidthcard-image-height-max: 420px;
-
-  @media (--fullwidthcard-largest) {
-    --fullwidthcard-image-height-max: 650px;
-  }
-
-  --fullwidthcard-image-height-fixed: 300px;
-
-  @media (--fullwidthcard-media-large) {
-    --fullwidthcard-image-height-fixed: 600px;
-  }
+  --fullwidthcard-image-maxheight-small: 420px;
+  --fullwidthcard-image-maxheight-medium: 650px;
+  --fullwidthcard-image-height-small: 300px;
+  --fullwidthcard-image-height-medium: 600px;
 }
 
 .hds-card.hds-card--full-width {
   max-width: inherit;
+  container-type: inline-size;
+  container-name: fullwidthcard;
 
   * {
     box-sizing: border-box;
@@ -32,35 +26,35 @@
     overflow: hidden;
     position: relative;
     border-radius: var(--hds-border-radius-8);
-    max-height: var(--fullwidthcard-image-height-max);
+    max-height: var(--fullwidthcard-image-maxheight-small);
     width: 100%;
 
     /*  Responsivity: different card layouts and content/images sizes,
-			while still displaying as much as the image as possible and trying to keep focus on the middle,
-			.hds-card__media is displayed in particular ways on particular viewport widths,
-			 but always filling the available width
-			 (which below 800px is the full width of the card minus padding,
-			 and above 800px is only half the width of the card):
-		*/
+				while still displaying as much as the image as possible and trying to keep focus on the middle,
+				.hds-card__media is displayed in particular ways on particular viewport widths,
+				 but always filling the available width
+				 (which below 800px is the full width of the card minus padding,
+				 and above 800px is only half the width of the card):
+			*/
 
     /* Narrowest: fixed aspect ratio (portrait: height is 1.5 times the width). */
-    @media (--fullwidthcard-media-narrowest) {
+    @container fullwidthcard (width < 308px) {
       aspect-ratio: var(--fullwidthcard-image-aspect-mini);
     }
 
     /* Second narrowest: fixed image height */
-    @media (--fullwidthcard-media-narrow) {
-      height: var(--fullwidthcard-image-height-fixed);
+    @container fullwidthcard (width >= 308px) and (width < 412px) {
+      height: var(--fullwidthcard-image-height-small);
     }
 
     /* Middle narrow: fixed aspect ratio (quare format), variable height */
-    @media (--fullwidthcard-media-mid) {
+    @container fullwidthcard (width >= 412px) and (width < 648px) {
       aspect-ratio: 1;
     }
 
     /* "Widest" narrow card layout: fixed image height (but higher now) */
-    @media (--fullwidthcard-media-large) {
-      height: var(--fullwidthcard-image-height-fixed);
+    @container fullwidthcard (width >= 648px) and (width < 800px) {
+      height: var(--fullwidthcard-image-height-medium);
     }
   }
 
@@ -73,11 +67,14 @@
 	Image height is at least 400px high, but scales up if the body text is higher.
 	Image has a max height if the text is huge, limiting the aspect ratio of the image.
  */
-@media (--fullwidthcard-largest) {
+
+/* TODO: THIS IS THE CONTAINER ITSELF! HOW TO SET THIS UP WITHOUT KNOWING THE PARENT ABOVE IT? */
+@container fullwidthcard (width >= 800px) {
   .hds-card.hds-card--full-width {
     display: flex;
     flex-direction: row;
     gap: var(--hds-spacing-12-16);
+    max-height: var(--fullwidthcard-image-maxheight-medium);
 
     & > .hds-card__media,
     & > .hds-card__body {
@@ -86,9 +83,10 @@
     }
 
     /* Image is absolutely positioned within .hds-card__media,
-       to center and avoid making .hds-card__media outgrow the body text: */
+		   to center and avoid making .hds-card__media outgrow the body text: */
 
     /* stylelint-disable selector-class-pattern */
+
     .hds-card__media > .hds-card__media__img {
       position: absolute;
       top: 50%;
@@ -97,6 +95,7 @@
     }
 
     /* Body sizes itself based on its content, and centers the contained wrapper (.hds-card__centerbody) vertically: */
+
     .hds-card__body {
       align-self: flex-start;
       display: flex;

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -84,7 +84,8 @@
       min-height: var(--fullwidthcard-content-min-height);
     }
 
-    /* Image is absolutely positioned and centered within .hds-card__media, to avoid making .hds-card__media outgrow the body text. */
+    /* Image is absolutely positioned within .hds-card__media,
+       to center and avoid making .hds-card__media outgrow the body text: */
     .hds-card__media > .hds-card__media--img {
       position: absolute;
       top: 50%;
@@ -92,7 +93,7 @@
       transform: translate(-50%, -50%);
     }
 
-    /* Body sizes itself based on its content */
+    /* Body sizes itself based on its content, and centers the contained wrapper (.hds-card__centerbody) vertically: */
     .hds-card__body {
       align-self: flex-start;
       display: flex;

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -56,16 +56,22 @@
     }
   }
 
-  .hds-card__centerbody {
-    margin: var(--hds-spacing-32-40);
-  }
+  .hds-card__body {
+    .hds-card__centerbody {
+      margin: var(--hds-spacing-32-40);
+    }
 
-  .hds-card__body-description {
-    margin-top: var(--hds-spacing-20-24);
-  }
+    .hds-card__body-description {
+      margin-top: var(--hds-spacing-20-24);
+    }
 
-  .hds-card__body-action {
-    margin-top: var(--hds-spacing-20-24);
+    .hds-card__body-action {
+      margin-top: var(--hds-spacing-20-24);
+    }
+
+    .hds-button {
+      margin-top: var(--hds-spacing-20-24);
+    }
   }
 
   /*  Wide layout: image to the left or right of the text. Image height is at least 400px high, but scales up if the

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -99,6 +99,10 @@
       transform: translate(-50%, -50%);
     }
 
+    &.hds-card--imagepos-right .hds-card__media {
+      order: 2;
+    }
+
     /* Body sizes itself based on its content, and centers the contained wrapper (.hds-card__centerbody) vertically: */
 
     .hds-card__body {

--- a/packages/css/src/card/fullwidth-card.css
+++ b/packages/css/src/card/fullwidth-card.css
@@ -16,10 +16,6 @@
   container-type: inline-size;
   container-name: fullwidthcard;
 
-  * {
-    box-sizing: border-box;
-  }
-
   .hds-card__layoutwrapper {
     height: 100%;
     width: 100%;
@@ -61,18 +57,20 @@
       margin: var(--hds-spacing-32-40);
     }
 
+    .hds-card__body-header {
+      margin-bottom: var(--hds-spacing-20-24);
+    }
+
     .hds-card__body-description {
-      margin-top: var(--hds-spacing-20-24);
+      margin-bottom: var(--hds-spacing-20-24);
     }
 
     .hds-card__body-action-row {
       display: flex;
       flex-wrap: wrap;
       gap: var(--hds-spacing-8);
-      margin-top: var(--hds-spacing-20-24);
 
       .hds-button {
-        border-radius: var(--hds-border-radius-8);
         flex: 1 0 160px;
         white-space: nowrap;
       }
@@ -80,10 +78,6 @@
 
     .hds-card__body-action {
       margin-top: 0;
-    }
-
-    .hds-link.hds-card__body-action {
-      margin-top: var(--hds-spacing-20-24);
     }
   }
 

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -42,7 +42,7 @@ export const CardBody = forwardRef<HTMLDivElement, CardBaseProps>(
     const Component = asChild ? Slot : "div";
     return (
       <Component {...rest} className={clsx("hds-card__body", className as undefined)} ref={ref}>
-        {children}
+        <div>{children}</div>
       </Component>
     );
   },

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -42,7 +42,7 @@ export const CardBody = forwardRef<HTMLDivElement, CardBaseProps>(
     const Component = asChild ? Slot : "div";
     return (
       <Component {...rest} className={clsx("hds-card__body", className as undefined)} ref={ref}>
-        <div>{children}</div>
+        <div className="hds-card__centerbody">{children}</div>
       </Component>
     );
   },

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -42,7 +42,7 @@ export const CardBody = forwardRef<HTMLDivElement, CardBaseProps>(
     const Component = asChild ? Slot : "div";
     return (
       <Component {...rest} className={clsx("hds-card__body", className as undefined)} ref={ref}>
-        <div className="hds-card__centerbody">{children}</div>
+        <div className={clsx("hds-card__centerbody", className as undefined)}>{children}</div>
       </Component>
     );
   },
@@ -204,25 +204,38 @@ export interface CardProps extends CardBaseProps {
    * @default "lighter-brand"
    * */
   color?: "white" | "lighter-brand" | "light-grey-fill";
-  /**
-   * On cards that can have images to the left or right of the text, (fullwidth or focus),
-   * left position is default. Setting imageRight to true, puts the image to the right.
-   *
-   * @default false
-   * */
-  imageRight?: boolean;
+
+  /* Only fullwidth or focus cards can have images to the left or right of the text: */
+  imagePosition?: "left" | "right";
 }
 
 interface CardFocusProps extends CardBaseProps {
   as?: "section" | "div" | "article" | "aside";
   variant: "focus";
   color: "darker";
-  imageRight?: boolean;
+  /**
+   * fullwidth or focus cards can have images to the left or right of the text.
+   *
+   * @default "left"
+   * */
+  imagePosition?: "left" | "right";
 }
 
-export const Card = forwardRef<HTMLDivElement, CardProps | CardFocusProps>(
+interface CardFullwidthProps extends CardBaseProps {
+  as?: "section" | "div" | "article" | "aside";
+  variant: "full-width";
+  color: "white" | "lighter-brand" | "light-grey-fill";
+  /**
+   * fullwidth or focus cards can have images to the left or right of the text.
+   *
+   * @default false
+   * */
+  imagePosition?: "left" | "right";
+}
+
+export const Card = forwardRef<HTMLDivElement, CardProps | CardFocusProps | CardFullwidthProps>(
   (
-    { as: Tag = "section", asChild, className, children, variant, color, imageRight, ...rest },
+    { as: Tag = "section", asChild, className, children, variant, color, imagePosition, ...rest },
     ref,
   ) => {
     const Component = asChild ? Slot : Tag;
@@ -238,13 +251,13 @@ export const Card = forwardRef<HTMLDivElement, CardProps | CardFocusProps>(
           { "hds-card--color-white": effectiveColor === "white" },
           { "hds-card--color-light-grey-fill": effectiveColor === "light-grey-fill" },
           { "hds-card--color-darker": effectiveColor === "darker" },
-          { "hds-card--imagepos-right": imageRight },
+          { "hds-card--image-position-right": imagePosition === "right" },
           className as undefined,
         )}
         ref={ref}
       >
         {variant === "full-width" ? (
-          <div className="hds-card__layoutwrapper">{children}</div>
+          <div className={clsx("hds-card__layoutwrapper", className as undefined)}>{children}</div>
         ) : (
           children
         )}

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -204,16 +204,27 @@ export interface CardProps extends CardBaseProps {
    * @default "lighter-brand"
    * */
   color?: "white" | "lighter-brand" | "light-grey-fill";
+  /**
+   * On cards that can have images to the left or right of the text, (fullwidth or focus),
+   * left position is default. Setting imageRight to true, puts the image to the right.
+   *
+   * @default false
+   * */
+  imageRight?: boolean;
 }
 
 interface CardFocusProps extends CardBaseProps {
   as?: "section" | "div" | "article" | "aside";
   variant: "focus";
   color: "darker";
+  imageRight?: boolean;
 }
 
 export const Card = forwardRef<HTMLDivElement, CardProps | CardFocusProps>(
-  ({ as: Tag = "section", asChild, className, children, variant, color, ...rest }, ref) => {
+  (
+    { as: Tag = "section", asChild, className, children, variant, color, imageRight, ...rest },
+    ref,
+  ) => {
     const Component = asChild ? Slot : Tag;
     const effectiveColor = variant === "focus" && !color ? "darker" : color;
     return (
@@ -227,6 +238,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps | CardFocusProps>(
           { "hds-card--color-white": effectiveColor === "white" },
           { "hds-card--color-light-grey-fill": effectiveColor === "light-grey-fill" },
           { "hds-card--color-darker": effectiveColor === "darker" },
+          { "hds-card--imagepos-right": imageRight },
           className as undefined,
         )}
         ref={ref}

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -29,7 +29,7 @@ export const CardMediaImg = forwardRef<HTMLImageElement, CardImageMediaProps>(
     return (
       <Component
         {...rest}
-        className={clsx("hds-card__media__img", className as undefined)}
+        className={clsx("hds-card__media--img", className as undefined)}
         ref={ref}
       />
     );

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -187,7 +187,7 @@ export interface CardBaseProps extends React.HTMLAttributes<HTMLDivElement> {
   asChild?: boolean;
 }
 
-export interface CardProps extends CardBaseProps {
+export interface CardSlimAndMiniatureProps extends CardBaseProps {
   /**
    * Change the default rendered element for Card.
    */
@@ -197,7 +197,7 @@ export interface CardProps extends CardBaseProps {
    *
    * @default "slim"
    */
-  variant?: "slim" | "full-width" | "miniature" | "focus";
+  variant?: "slim" | "miniature";
   /**
    * The color of the card.
    *
@@ -206,13 +206,13 @@ export interface CardProps extends CardBaseProps {
   color?: "white" | "lighter-brand" | "light-grey-fill";
 
   /* Only fullwidth or focus cards can have images to the left or right of the text: */
-  imagePosition?: "left" | "right";
+  imagePosition?: never;
 }
 
-interface CardFocusProps extends CardBaseProps {
+export interface CardFocusProps extends CardBaseProps {
   as?: "section" | "div" | "article" | "aside";
   variant: "focus";
-  color: "darker";
+  color?: "darker";
   /**
    * fullwidth or focus cards can have images to the left or right of the text.
    *
@@ -221,19 +221,21 @@ interface CardFocusProps extends CardBaseProps {
   imagePosition?: "left" | "right";
 }
 
-interface CardFullwidthProps extends CardBaseProps {
+export interface CardFullwidthProps extends CardBaseProps {
   as?: "section" | "div" | "article" | "aside";
   variant: "full-width";
   color: "white" | "lighter-brand" | "light-grey-fill";
   /**
    * fullwidth or focus cards can have images to the left or right of the text.
    *
-   * @default false
+   * @default "left"
    * */
   imagePosition?: "left" | "right";
 }
 
-export const Card = forwardRef<HTMLDivElement, CardProps | CardFocusProps | CardFullwidthProps>(
+export type CardProps = CardSlimAndMiniatureProps | CardFocusProps | CardFullwidthProps;
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(
   (
     { as: Tag = "section", asChild, className, children, variant, color, imagePosition, ...rest },
     ref,

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -143,6 +143,22 @@ export const CardBodyAction = forwardRef<HTMLDivElement, CardBaseProps>(
 );
 CardBodyAction.displayName = "Card.BodyAction";
 
+export const CardBodyActionRow = forwardRef<HTMLDivElement, CardBaseProps>(
+  ({ asChild, className, children, ...rest }, ref) => {
+    const Component = asChild ? Slot : "div";
+    return (
+      <Component
+        {...rest}
+        className={clsx("hds-card__body-action-row", className as undefined)}
+        ref={ref}
+      >
+        {children}
+      </Component>
+    );
+  },
+);
+CardBodyActionRow.displayName = "Card.BodyActionRow";
+
 interface CardBodyActionArrowProps extends React.HTMLAttributes<HTMLSpanElement> {
   /**
    * Change the default rendered element for the one passed as a child, merging their props and behavior.
@@ -277,6 +293,7 @@ Card.BodyHeaderOverline = CardBodyHeaderOverline;
 Card.BodyHeaderTitle = CardBodyHeaderTitle;
 Card.BodyDescription = CardBodyDescription;
 Card.BodyAction = CardBodyAction;
+Card.BodyActionRow = CardBodyActionRow;
 Card.BodyActionArrow = CardBodyActionArrow;
 
 type CardType = ReturnType<typeof forwardRef<HTMLDivElement, CardProps>> & {
@@ -288,5 +305,6 @@ type CardType = ReturnType<typeof forwardRef<HTMLDivElement, CardProps>> & {
   BodyHeaderTitle: typeof CardBodyHeaderTitle;
   BodyDescription: typeof CardBodyDescription;
   BodyAction: typeof CardBodyAction;
+  BodyActionRow: typeof CardBodyActionRow;
   BodyActionArrow: typeof CardBodyActionArrow;
 };

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -231,7 +231,11 @@ export const Card = forwardRef<HTMLDivElement, CardProps | CardFocusProps>(
         )}
         ref={ref}
       >
-        {children}
+        {variant === "full-width" ? (
+          <div className="hds-card__layoutwrapper">{children}</div>
+        ) : (
+          children
+        )}
       </Component>
     );
   },

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -29,7 +29,7 @@ export const CardMediaImg = forwardRef<HTMLImageElement, CardImageMediaProps>(
     return (
       <Component
         {...rest}
-        className={clsx("hds-card__media--img", className as undefined)}
+        className={clsx("hds-card__media__img", className as undefined)}
         ref={ref}
       />
     );


### PR DESCRIPTION
Some custom responsive styling of fullwidth cards, to make images and text behave as spec'ed.

Works with all aspects of images as long as the interesting area is more or less in the middle. Recommended: use square source images.