### PR TITLE
Fullwidthcard lightercolor class

### DIFF
--- a/.changeset/red-jeans-prove.md
+++ b/.changeset/red-jeans-prove.md
@@ -1,0 +1,6 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+Default lighter-brand backgroundcolor on fullwidthcard marked with a class of its own

--- a/packages/css/src/card/card.css
+++ b/packages/css/src/card/card.css
@@ -8,7 +8,6 @@
   position: relative;
   border-bottom: initial;
   text-decoration: initial;
-  background-color: var(--hds-colors-lighter);
   border-radius: var(--hds-border-radius-16);
   display: flex;
   flex-direction: column;
@@ -123,6 +122,10 @@
 
 .hds-card--color-darker {
   background-color: var(--hds-colors-darker);
+}
+
+.hds-card--color-lighter {
+  background-color: var(--hds-colors-lighter);
 }
 
 .hds-card--focus {

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -271,7 +271,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
     ref,
   ) => {
     const Component = asChild ? Slot : Tag;
-    const effectiveColor = variant === "focus" && !color ? "darker" : color;
+    const effectiveColor = variant === "focus" && !color ? "darker" : (color ?? "lighter-brand");
     return (
       <Component
         {...rest}
@@ -282,6 +282,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
           { "hds-card--focus": variant === "focus" },
           { "hds-card--color-white": effectiveColor === "white" },
           { "hds-card--color-light-grey-fill": effectiveColor === "light-grey-fill" },
+          { "hds-card--color-lighter": effectiveColor === "lighter-brand" },
           { "hds-card--color-darker": effectiveColor === "darker" },
           { "hds-card--image-position-right": imagePosition === "right" },
           className as undefined,


### PR DESCRIPTION
Postenbring needs to locally override the default color (lighter-theme) on cards, but not the other colors. Cleanest to achieve this if the default color has a class of its own.