### PR TITLE
Size navbar title by CSS instead of JS

### DIFF
--- a/.changeset/sour-bugs-tan.md
+++ b/.changeset/sour-bugs-tan.md
@@ -1,0 +1,6 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+Set width of navbar menu label, by pure CSS instead of JS

--- a/packages/css/src/navbar/navbar.css
+++ b/packages/css/src/navbar/navbar.css
@@ -111,6 +111,29 @@
       }
     }
 
+    &.hds-navbar__item--open {
+      .hds-navbar__item-whenclosedtext {
+        height: 0;
+      }
+    }
+
+    &.hds-navbar__item--closed {
+      .hds-navbar__item-whenopentext {
+        height: 0;
+      }
+    }
+
+    .hds-navbar__item-responsive-text {
+      display: block;
+      text-align: right;
+
+      * {
+        white-space: nowrap;
+        display: block;
+        overflow-y: hidden;
+      }
+    }
+
     @media (--before-large) {
       .hds-navbar__item-icon {
         width: var(--hds-spacing-24);

--- a/packages/react/src/navbar/navbar-expandable-menu.tsx
+++ b/packages/react/src/navbar/navbar-expandable-menu.tsx
@@ -8,6 +8,7 @@ interface ExpandableMenuContextProps {
   setOpen: (open: boolean) => void;
   contentId: string;
 }
+
 const ExpandableMenuContext = createContext<ExpandableMenuContextProps | null>(null);
 export const useNavbarExpendableMenuContext = () => {
   const value = useContext(ExpandableMenuContext);
@@ -53,6 +54,7 @@ export function NavbarExpandableMenu({ children }: NavbarExpandableMenuProps) {
     </ExpandableMenuContext.Provider>
   );
 }
+
 NavbarExpandableMenu.displayName = "NavbarExpandableMenu";
 
 /**
@@ -66,6 +68,7 @@ export interface NavbarExpandableMenuTriggerProps
   whenOpenText: React.ReactNode;
   whenOpenHelperTitle?: string;
 }
+
 export const NavbarExpandableMenuTrigger = forwardRef<
   HTMLButtonElement,
   NavbarExpandableMenuTriggerProps
@@ -86,23 +89,6 @@ export const NavbarExpandableMenuTrigger = forwardRef<
   ) => {
     const { contentId, open, setOpen } = useNavbarExpendableMenuContext();
 
-    // Measure the width of the text when open and closed and choose the widest one
-    // This is to ensure that the button doesn't change size when the text changes
-    const [textWidth, setTextWidth] = useState<number | undefined>(undefined);
-    const measurementId = useId();
-    useEffect(() => {
-      const widthWhenOpen =
-        document.getElementById(`${measurementId}-when-open`)?.getBoundingClientRect().width ?? 0;
-      const widthWhenClosed =
-        document.getElementById(`${measurementId}-when-closed`)?.getBoundingClientRect().width ?? 0;
-
-      setTextWidth(widthWhenOpen < widthWhenClosed ? widthWhenClosed : widthWhenOpen);
-    }, [measurementId]);
-
-    const text = open ? whenOpenText : whenClosedText;
-    const title = open ? whenOpenHelperTitle : whenClosedHelperTitle;
-    const icon = open ? <CloseIcon /> : <MenuIcon />;
-
     function toggleOpen() {
       setOpen(!open);
     }
@@ -111,48 +97,27 @@ export const NavbarExpandableMenuTrigger = forwardRef<
       <button
         aria-expanded={open}
         aria-controls={contentId}
-        className={clsx("hds-navbar__item", className as undefined)}
+        className={clsx(
+          "hds-navbar__item",
+          className as undefined,
+          open ? "hds-navbar__item--open" : "hds-navbar__item--closed",
+        )}
         onClick={toggleOpen}
         ref={ref}
-        title={title}
+        title={open ? whenOpenHelperTitle : whenClosedHelperTitle}
         type="button"
         style={{ position: "relative", ...style }}
         {...rest}
       >
-        {/* Measurement elements, not shown to the user */}
-        <span
-          id={`${measurementId}-when-closed`}
-          aria-hidden
-          style={{
-            position: "absolute",
-            visibility: "hidden",
-            pointerEvents: "none",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {whenOpenText}
+        <span className="hds-navbar__item-responsive-text">
+          <span aria-hidden={!open} className={clsx("hds-navbar__item-whenopentext")}>
+            {whenOpenText}
+          </span>
+          <span aria-hidden={open} className={clsx("hds-navbar__item-whenclosedtext")}>
+            {whenClosedText}
+          </span>
         </span>
-        <span
-          id={`${measurementId}-when-open`}
-          aria-hidden
-          style={{
-            position: "absolute",
-            visibility: "hidden",
-            pointerEvents: "none",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {whenClosedText}
-        </span>
-
-        {/* Actual content */}
-        <span
-          style={{ width: textWidth, whiteSpace: "nowrap" }}
-          className={clsx("hds-navbar__item-responsive-text")}
-        >
-          {text}
-        </span>
-        <span style={{ width: 32, height: 32 }}>{icon}</span>
+        <span style={{ width: 32, height: 32 }}>{open ? <CloseIcon /> : <MenuIcon />}</span>
       </button>
     );
   },
@@ -166,6 +131,7 @@ export interface NavbarExpandableMenuContentProps {
   children: React.ReactNode;
   className?: string;
 }
+
 export const NavbarExpandableMenuContent = forwardRef<
   HTMLDivElement,
   NavbarExpandableMenuContentProps


### PR DESCRIPTION
Alters the DOM of the navbar button label: two spans with the two texts, that are both placed in a wrapper element that gets the width of the widest one of them. They are placed above one another, but depending on the `open` value, are hidden by `height: 0` and hidden overflow-y.