### PR TITLE
Make Slim and Miniature cards links align when placed side-by-side

### DIFF
--- a/.changeset/chilly-dolls-jog.md
+++ b/.changeset/chilly-dolls-jog.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-css": patch
+---
+
+Make Slim and Miniature cards links align when placed side-by-side

--- a/packages/css/src/card/card.css
+++ b/packages/css/src/card/card.css
@@ -200,12 +200,6 @@
   }
 }
 
-.hds-card--slim {
-  .hds-card__media {
-    margin-bottom: var(--hds-spacing-12-16);
-  }
-}
-
 .hds-card--slim,
 .hds-card--miniature {
   .hds-card__centerbody {

--- a/packages/css/src/card/card.css
+++ b/packages/css/src/card/card.css
@@ -35,6 +35,13 @@
     }
   }
 
+  .hds-card__body {
+    flex: 1 0 auto;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
   .hds-card__body-header {
     margin-top: 0;
     margin-bottom: 0;
@@ -145,9 +152,6 @@
   }
 
   .hds-card__body {
-    display: flex;
-    flex: 1 0 auto;
-    flex-direction: column;
     padding: var(--hds-spacing-32-40);
 
     @media (--large) {
@@ -185,9 +189,7 @@
   }
 
   .hds-card__body {
-    display: flex;
-    flex-direction: column;
-    flex: 0 1 auto;
+    flex-basis: min-content;
     padding-top: 0;
 
     .hds-card__body-header-title {

--- a/packages/css/src/card/card.css
+++ b/packages/css/src/card/card.css
@@ -35,13 +35,6 @@
     }
   }
 
-  .hds-card__body {
-    flex: 1 0 auto;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-  }
-
   .hds-card__body-header {
     margin-top: 0;
     margin-bottom: 0;
@@ -152,6 +145,9 @@
   }
 
   .hds-card__body {
+    display: flex;
+    flex: 1 0 auto;
+    flex-direction: column;
     padding: var(--hds-spacing-32-40);
 
     @media (--large) {
@@ -189,7 +185,9 @@
   }
 
   .hds-card__body {
-    flex-basis: min-content;
+    display: flex;
+    flex-direction: column;
+    flex: 0 1 auto;
     padding-top: 0;
 
     .hds-card__body-header-title {
@@ -203,5 +201,15 @@
 .hds-card--slim {
   .hds-card__media {
     margin-bottom: var(--hds-spacing-12-16);
+  }
+}
+
+.hds-card--slim,
+.hds-card--miniature {
+  .hds-card__centerbody {
+    height: 100%;
+    flex: 1 0 auto;
+    display: flex;
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
This functionality had broken somewhere along the way