### PR TITLE
Update Error Summary to new design

### DIFF
--- a/.changeset/tiny-lemons-shop.md
+++ b/.changeset/tiny-lemons-shop.md
@@ -1,0 +1,6 @@
+---
+"@postenbring/hedwig-css": patch
+"@postenbring/hedwig-react": patch
+---
+
+Update Error Summary to new design

--- a/packages/css/src/form/error-summary/error-summary.css
+++ b/packages/css/src/form/error-summary/error-summary.css
@@ -1,0 +1,14 @@
+.hds-error-summary {
+  background-color: var(--hds-posten-colors-dark-red);
+  display: flex;
+  flex-direction: column;
+  gap: var(--hds-spacing-12);
+
+  .hds-error-summary__title {
+    color: var(--hds-ui-colors-white);
+  }
+
+  .hds-error-summary__list-item::marker {
+    color: var(--hds-ui-colors-white);
+  }
+}

--- a/packages/css/src/form/error-summary/error-summary.css
+++ b/packages/css/src/form/error-summary/error-summary.css
@@ -5,6 +5,7 @@
   gap: var(--hds-spacing-12);
 
   .hds-error-summary__title {
+    font: var(--hds-typography-body-title);
     color: var(--hds-ui-colors-white);
   }
 

--- a/packages/css/src/index.css
+++ b/packages/css/src/index.css
@@ -20,6 +20,7 @@
 @import url("form/checkbox/checkbox.css");
 @import url("form/date-picker/date-picker.css");
 @import url("form/error-message/error-message.css");
+@import url("form/error-summary/error-summary.css");
 @import url("form/fieldset/fieldset.css");
 @import url("form/input/input.css");
 @import url("form/input-group/input-group.css");

--- a/packages/react/src/form/error-summary/error-summary.tsx
+++ b/packages/react/src/form/error-summary/error-summary.tsx
@@ -1,6 +1,5 @@
-import { forwardRef, useEffect, useRef } from "react";
+import { forwardRef, useEffect, useRef, type HTMLAttributes } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
-import { type AlertTitleProps } from "../../alert";
 import { Text } from "../../text";
 import { Box, type BoxProps } from "../../box";
 import { UnorderedList, type ListProps } from "../../list";
@@ -38,7 +37,7 @@ interface ErrorSummaryHeadingPropsAsChild {
   as?: never;
 }
 
-export type ErrorSummaryHeadingProps = AlertTitleProps &
+export type ErrorSummaryHeadingProps = HTMLAttributes<HTMLParagraphElement> &
   ErrorSummaryHeadingPropsAutoFocus &
   (ErrorSummaryHeadingPropsAs | ErrorSummaryHeadingPropsAsChild);
 

--- a/packages/react/src/form/error-summary/error-summary.tsx
+++ b/packages/react/src/form/error-summary/error-summary.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, useRef, type HTMLAttributes } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
-import { Text } from "../../text";
+import { Slot } from "@radix-ui/react-slot";
 import { Box, type BoxProps } from "../../box";
 import { UnorderedList, type ListProps } from "../../list";
 import { Link } from "../../link";
@@ -37,16 +37,17 @@ interface ErrorSummaryHeadingPropsAsChild {
   as?: never;
 }
 
-export type ErrorSummaryHeadingProps = HTMLAttributes<HTMLParagraphElement> &
+export type ErrorSummaryHeadingProps = HTMLAttributes<HTMLElement> &
   ErrorSummaryHeadingPropsAutoFocus &
   (ErrorSummaryHeadingPropsAs | ErrorSummaryHeadingPropsAsChild);
 
 export const ErrorSummaryHeading = forwardRef<
   HTMLParagraphElement,
   ErrorSummaryHeadingProps & (ErrorSummaryHeadingPropsAs | ErrorSummaryHeadingPropsAsChild)
->(({ children, as: Tag, autoFocus = true, ...rest }, ref) => {
+>(({ asChild, children, as: Tag, autoFocus = true, ...rest }, ref) => {
   const focusRef = useRef<HTMLElement>(null);
   const mergedRef = useMergeRefs([focusRef, ref]);
+  const Component = asChild ? Slot : Tag;
 
   useEffect(() => {
     /**
@@ -62,16 +63,9 @@ export const ErrorSummaryHeading = forwardRef<
   }, []);
 
   return (
-    <Text
-      className={clsx(`hds-error-summary__title`)}
-      variant="body-title"
-      ref={mergedRef}
-      tabIndex={-1}
-      asChild
-      {...rest}
-    >
-      {Tag ? <Tag>{children}</Tag> : children}
-    </Text>
+    <Component className={clsx(`hds-error-summary__title`)} ref={mergedRef} tabIndex={-1} {...rest}>
+      {children}
+    </Component>
   );
 });
 ErrorSummaryHeading.displayName = "ErrorSummary.Heading";

--- a/packages/react/src/form/error-summary/error-summary.tsx
+++ b/packages/react/src/form/error-summary/error-summary.tsx
@@ -86,7 +86,7 @@ export interface ErrorSummaryListProps extends ListProps {
   size?: ListProps["size"];
 }
 export const ErrorSummaryList = forwardRef<HTMLUListElement, ErrorSummaryListProps>(
-  ({ children, style: _style, size = "small", ...rest }, ref) => (
+  ({ children, size = "small", ...rest }, ref) => (
     <UnorderedList size={size} ref={ref} {...rest}>
       {children}
     </UnorderedList>

--- a/packages/react/src/form/error-summary/error-summary.tsx
+++ b/packages/react/src/form/error-summary/error-summary.tsx
@@ -1,5 +1,8 @@
 import { forwardRef, useEffect, useRef } from "react";
-import { Message, type MessageProps, type MessageTitleProps } from "../../message";
+import { clsx } from "@postenbring/hedwig-css/typed-classname";
+import { type MessageTitleProps } from "../../message";
+import { Text } from "../../text";
+import { Box, type BoxProps } from "../../box";
 import { UnorderedList, type ListProps } from "../../list";
 import { Link } from "../../link";
 import { useMergeRefs } from "../../utils";
@@ -60,9 +63,16 @@ export const ErrorSummaryHeading = forwardRef<
   }, []);
 
   return (
-    <Message.Title ref={mergedRef} tabIndex={-1} asChild {...rest}>
+    <Text
+      className={clsx(`hds-error-summary__title`)}
+      variant="body-title"
+      ref={mergedRef}
+      tabIndex={-1}
+      asChild
+      {...rest}
+    >
       {Tag ? <Tag>{children}</Tag> : children}
-    </Message.Title>
+    </Text>
   );
 });
 ErrorSummaryHeading.displayName = "ErrorSummary.Heading";
@@ -76,20 +86,11 @@ export interface ErrorSummaryListProps extends ListProps {
   size?: ListProps["size"];
 }
 export const ErrorSummaryList = forwardRef<HTMLUListElement, ErrorSummaryListProps>(
-  ({ children, style: _style, size = "small", ...rest }, ref) => {
-    const style = {
-      // Match the link `solid` style, which black underline
-      "--_hds-list-marker-color": "var(--hds-ui-colors-black)",
-      ..._style,
-    };
-    return (
-      <Message.Description asChild>
-        <UnorderedList size={size} ref={ref} style={style} {...rest}>
-          {children}
-        </UnorderedList>
-      </Message.Description>
-    );
-  },
+  ({ children, style: _style, size = "small", ...rest }, ref) => (
+    <UnorderedList size={size} ref={ref} {...rest}>
+      {children}
+    </UnorderedList>
+  ),
 );
 ErrorSummaryList.displayName = "ErrorSummary.List";
 
@@ -118,8 +119,14 @@ export const ErrorSummaryItem = forwardRef<HTMLLIElement, ErrorSummaryItemProps>
     }
 
     return (
-      <li ref={ref} {...rest}>
-        <Link size="small" href={href} variant="solid" {...linkProps} onClick={onClick}>
+      <li className={clsx(`hds-error-summary__list-item`)} ref={ref} {...rest}>
+        <Link
+          size="small"
+          href={href}
+          variant="inverted-no-underline"
+          {...linkProps}
+          onClick={onClick}
+        >
           {children}
         </Link>
       </li>
@@ -128,16 +135,17 @@ export const ErrorSummaryItem = forwardRef<HTMLLIElement, ErrorSummaryItemProps>
 );
 ErrorSummaryItem.displayName = "ErrorSummary.Item";
 
-export type ErrorSummaryProps = Omit<MessageProps, "variant" | "icon" | "iconClassName">;
+export type ErrorSummaryProps = Omit<
+  BoxProps,
+  "variant" | "closeable" | "onClose" | "closed" | "closeButtonProps"
+>;
 
 export const ErrorSummary = forwardRef<HTMLDivElement, ErrorSummaryProps>(
-  ({ children, ...rest }, ref) => {
-    return (
-      <Message variant="warning" ref={ref} {...rest}>
-        {children}
-      </Message>
-    );
-  },
+  ({ children, className, ...rest }, ref) => (
+    <Box ref={ref} {...rest} className={clsx(`hds-error-summary`, className as undefined)}>
+      {children}
+    </Box>
+  ),
 ) as ErrorSummaryType;
 ErrorSummary.displayName = "ErrorSummary";
 

--- a/packages/react/src/form/error-summary/error-summary.tsx
+++ b/packages/react/src/form/error-summary/error-summary.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, useRef } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
-import { type MessageTitleProps } from "../../message";
+import { type AlertTitleProps } from "../../alert";
 import { Text } from "../../text";
 import { Box, type BoxProps } from "../../box";
 import { UnorderedList, type ListProps } from "../../list";
@@ -38,7 +38,7 @@ interface ErrorSummaryHeadingPropsAsChild {
   as?: never;
 }
 
-export type ErrorSummaryHeadingProps = MessageTitleProps &
+export type ErrorSummaryHeadingProps = AlertTitleProps &
   ErrorSummaryHeadingPropsAutoFocus &
   (ErrorSummaryHeadingPropsAs | ErrorSummaryHeadingPropsAsChild);
 


### PR DESCRIPTION
Changes Error summary from the old design:
<img width="551" alt="Screenshot 2025-07-04 at 13 05 13" src="https://github.com/user-attachments/assets/91feec42-918a-4dbc-b077-8505922fab21" />
.. to the new design:
![screenshot_2025-07-04_at_12 52 37_720](https://github.com/user-attachments/assets/24f884f1-d7ee-4e3e-aa21-4a41af94822d)

Link to figma: https://www.figma.com/proto/64ieYInJRps5diLI1qgJJk/Hedwig-Design-System?node-id=19017-5941&t=xpJqoQxnFpWbcy85-1
