### PR TITLE
Pass boolean to inert

### DIFF
--- a/.changeset/legal-houses-go.md
+++ b/.changeset/legal-houses-go.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-react": minor
+---
+
+Pass boolean instead of string to inert attribute

--- a/packages/react/src/accordion/accordion-content.tsx
+++ b/packages/react/src/accordion/accordion-content.tsx
@@ -17,7 +17,7 @@ export const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps
       <div
         id={context.contentId}
         data-state={context.open ? "open" : "closed"}
-        {...{ inert: context.open ? undefined : "true" }}
+        {...{ inert: context.open ? undefined : true }}
         className={clsx("hds-accordion-item-content", className as undefined)}
         ref={ref}
         {...rest}

--- a/packages/react/src/navbar/navbar-expandable-menu.tsx
+++ b/packages/react/src/navbar/navbar-expandable-menu.tsx
@@ -143,7 +143,7 @@ export const NavbarExpandableMenuContent = forwardRef<
       id={contentId}
       className={clsx("hds-navbar__expandable-menu-content", className as undefined)}
       data-state={open ? "open" : "closed"}
-      {...{ inert: open ? undefined : "true" }}
+      {...{ inert: open ? undefined : true }}
       ref={ref}
     >
       <div className={clsx("hds-navbar__expandable-menu-content-inner")}>{children}</div>

--- a/packages/react/src/skeleton/skeleton.tsx
+++ b/packages/react/src/skeleton/skeleton.tsx
@@ -102,7 +102,7 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
         )}
         style={{ ...style, width, height }}
         aria-hidden
-        {...{ inert: "true" }}
+        {...{ inert: true }}
         ref={ref as any}
         {...(rest as any)}
       >


### PR DESCRIPTION
Getting this error in react 19: 
<img width="719" height="136" alt="image" src="https://github.com/user-attachments/assets/c28a2f46-24ff-4809-a80d-20423492d957" />

Haven't tested it but assume this PR consolidates the error, the typing for inert is also `undefined | boolean`.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert