### PR TITLE
Inert prop react 19

### DIFF
--- a/.changeset/stupid-jars-prove.md
+++ b/.changeset/stupid-jars-prove.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-react": patch
+---
+
+Handle `inert` prop in both React 18 and 19

--- a/packages/react/src/accordion/accordion-content.tsx
+++ b/packages/react/src/accordion/accordion-content.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { forwardRef, useContext } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
+import { isInert } from "../utils";
 import { AccordionItemContext } from "./context";
 
 export interface AccordionContentProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -17,7 +18,7 @@ export const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps
       <div
         id={context.contentId}
         data-state={context.open ? "open" : "closed"}
-        {...{ inert: context.open ? undefined : "true" }}
+        {...{ inert: isInert(!context.open) }}
         className={clsx("hds-accordion-item-content", className as undefined)}
         ref={ref}
         {...rest}

--- a/packages/react/src/accordion/accordion-content.tsx
+++ b/packages/react/src/accordion/accordion-content.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { forwardRef, useContext } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
-import { isInert } from "../utils";
+import { inertPropValue } from "../utils";
 import { AccordionItemContext } from "./context";
 
 export interface AccordionContentProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -18,7 +18,7 @@ export const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps
       <div
         id={context.contentId}
         data-state={context.open ? "open" : "closed"}
-        {...{ inert: isInert(!context.open) }}
+        {...{ inert: inertPropValue(!context.open) }}
         className={clsx("hds-accordion-item-content", className as undefined)}
         ref={ref}
         {...rest}

--- a/packages/react/src/navbar/navbar-expandable-menu.tsx
+++ b/packages/react/src/navbar/navbar-expandable-menu.tsx
@@ -1,6 +1,6 @@
-import { createContext, useContext, forwardRef, useState, useEffect, useId, version } from "react";
+import { createContext, useContext, forwardRef, useState, useEffect, useId } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
-import { focusTrap } from "../utils/utils";
+import { focusTrap, isInert } from "../utils/utils";
 import { CloseIcon, MenuIcon } from "./icons";
 
 interface ExpandableMenuContextProps {
@@ -137,12 +137,6 @@ export const NavbarExpandableMenuContent = forwardRef<
   NavbarExpandableMenuContentProps
 >(({ children, className, ...rest }, ref) => {
   const { contentId, open } = useNavbarExpendableMenuContext();
-
-  const inertBooleanSupported = Number(version.split(".")[0]) >= 19; // React 19 supports inert attribute
-
-  const isInert = inertBooleanSupported
-    ? (x: boolean) => x
-    : (x: boolean) => (x ? "" : undefined) as unknown as boolean; // Use undefined for React 19+ to avoid inert attribute
 
   return (
     <section

--- a/packages/react/src/navbar/navbar-expandable-menu.tsx
+++ b/packages/react/src/navbar/navbar-expandable-menu.tsx
@@ -142,7 +142,7 @@ export const NavbarExpandableMenuContent = forwardRef<
 
   const isInert = inertBooleanSupported
     ? (x: boolean) => x
-    : (x: boolean) => (x ? "true" : undefined) as unknown as boolean; // Use undefined for React 19+ to avoid inert attribute
+    : (x: boolean) => (x ? "" : undefined) as unknown as boolean; // Use undefined for React 19+ to avoid inert attribute
 
   return (
     <section

--- a/packages/react/src/navbar/navbar-expandable-menu.tsx
+++ b/packages/react/src/navbar/navbar-expandable-menu.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, forwardRef, useState, useEffect, useId } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
-import { focusTrap, isInert } from "../utils/utils";
+import { focusTrap, inertPropValue } from "../utils/utils";
 import { CloseIcon, MenuIcon } from "./icons";
 
 interface ExpandableMenuContextProps {
@@ -144,7 +144,7 @@ export const NavbarExpandableMenuContent = forwardRef<
       id={contentId}
       className={clsx("hds-navbar__expandable-menu-content", className as undefined)}
       data-state={open ? "open" : "closed"}
-      {...{ inert: isInert(!open) }}
+      {...{ inert: inertPropValue(!open) }}
       ref={ref}
     >
       <div className={clsx("hds-navbar__expandable-menu-content-inner")}>{children}</div>

--- a/packages/react/src/navbar/navbar-expandable-menu.tsx
+++ b/packages/react/src/navbar/navbar-expandable-menu.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, forwardRef, useState, useEffect, useId } from "react";
+import { createContext, useContext, forwardRef, useState, useEffect, useId, version } from "react";
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
 import { focusTrap } from "../utils/utils";
 import { CloseIcon, MenuIcon } from "./icons";
@@ -137,13 +137,20 @@ export const NavbarExpandableMenuContent = forwardRef<
   NavbarExpandableMenuContentProps
 >(({ children, className, ...rest }, ref) => {
   const { contentId, open } = useNavbarExpendableMenuContext();
+
+  const inertBooleanSupported = Number(version.split(".")[0]) >= 19; // React 19 supports inert attribute
+
+  const isInert = inertBooleanSupported
+    ? (x: boolean) => x
+    : (x: boolean) => (x ? "true" : undefined) as unknown as boolean; // Use undefined for React 19+ to avoid inert attribute
+
   return (
     <section
       {...rest}
       id={contentId}
       className={clsx("hds-navbar__expandable-menu-content", className as undefined)}
       data-state={open ? "open" : "closed"}
-      {...{ inert: open ? undefined : "true" }}
+      {...{ inert: isInert(!open) }}
       ref={ref}
     >
       <div className={clsx("hds-navbar__expandable-menu-content-inner")}>{children}</div>

--- a/packages/react/src/skeleton/skeleton.tsx
+++ b/packages/react/src/skeleton/skeleton.tsx
@@ -4,6 +4,7 @@
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
 import { Slot } from "@radix-ui/react-slot";
 import { forwardRef } from "react";
+import { isInert } from "../utils";
 
 interface DimensionsFromWidthAndHeight {
   height?: number | string;
@@ -102,7 +103,7 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
         )}
         style={{ ...style, width, height }}
         aria-hidden
-        {...{ inert: "true" }}
+        {...{ inert: isInert(true) }}
         ref={ref as any}
         {...(rest as any)}
       >

--- a/packages/react/src/skeleton/skeleton.tsx
+++ b/packages/react/src/skeleton/skeleton.tsx
@@ -4,7 +4,7 @@
 import { clsx } from "@postenbring/hedwig-css/typed-classname";
 import { Slot } from "@radix-ui/react-slot";
 import { forwardRef } from "react";
-import { isInert } from "../utils";
+import { inertPropValue } from "../utils";
 
 interface DimensionsFromWidthAndHeight {
   height?: number | string;
@@ -103,7 +103,7 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
         )}
         style={{ ...style, width, height }}
         aria-hidden
-        {...{ inert: isInert(true) }}
+        {...{ inert: inertPropValue(true) }}
         ref={ref as any}
         {...(rest as any)}
       >

--- a/packages/react/src/utils/utils.ts
+++ b/packages/react/src/utils/utils.ts
@@ -115,6 +115,9 @@ function releaseFocusTrap(inertElements: Iterable<HTMLElement>) {
  */
 const inertBooleanSupported: boolean = Number(version.split(".")[0]) >= 19;
 
-export const isInert: (x: boolean) => boolean | "" | undefined = inertBooleanSupported
+/**
+ * Returns the inert prop value based on the React version.
+ */
+export const inertPropValue: (x: boolean) => boolean | "" | undefined = inertBooleanSupported
   ? (x: boolean): boolean => x
   : (x: boolean): "" | undefined => (x ? "" : undefined);

--- a/packages/react/src/utils/utils.ts
+++ b/packages/react/src/utils/utils.ts
@@ -109,7 +109,11 @@ function releaseFocusTrap(inertElements: Iterable<HTMLElement>) {
   }
 }
 
-const inertBooleanSupported: boolean = Number(version.split(".")[0]) >= 19; // React 19 supports inert attribute
+/**
+ * React 19 supports inert prop
+ * React 18 needs inert to be a string
+ */
+const inertBooleanSupported: boolean = Number(version.split(".")[0]) >= 19;
 
 export const isInert: (x: boolean) => boolean | "" | undefined = inertBooleanSupported
   ? (x: boolean): boolean => x

--- a/packages/react/src/utils/utils.ts
+++ b/packages/react/src/utils/utils.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, version } from "react";
 
 /**
  * Merges an array of refs into a single memoized callback ref or `null`.
@@ -108,3 +108,9 @@ function releaseFocusTrap(inertElements: Iterable<HTMLElement>) {
     el.removeAttribute("inert");
   }
 }
+
+const inertBooleanSupported: boolean = Number(version.split(".")[0]) >= 19; // React 19 supports inert attribute
+
+export const isInert: (x: boolean) => boolean | "" | undefined = inertBooleanSupported
+  ? (x: boolean): boolean => x
+  : (x: boolean): "" | undefined => (x ? "" : undefined);


### PR DESCRIPTION
Make the `inert` prop behave properly in both React 18 and 19

Updated for
- Accordion
- Navbar
- Skeleton

Background:
The `inert` prop is finally supported in React 19 as a boolean.
Unfortunately this means that using `inert="true"`now adds warning messages in the console when using React 19
Simply switching to using `inert={true}` is not supported in React 18.

This will check if React is version >=19 and act accordingly

Inspired by: https://stackoverflow.com/a/78606437