### PR TITLE
Remove margin-right from miniature card media

### DIFF
--- a/packages/css/src/card/card.css
+++ b/packages/css/src/card/card.css
@@ -185,7 +185,6 @@
     max-width: 60px;
     object-fit: cover;
     background-color: var(--hds-ui-colors-white);
-    margin-right: var(--hds-spacing-12-16);
   }
 
   .hds-card__body {


### PR DESCRIPTION
For some reason it had both margin and gap