### PR TITLE
Mediaimg flip defaultvariant

### DIFF
--- a/.changeset/shaky-oranges-push.md
+++ b/.changeset/shaky-oranges-push.md
@@ -1,0 +1,6 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+Flip default way of scaling Card.MediaImg from crop to scale

--- a/apps/examples/app/examples/card/focus.tsx
+++ b/apps/examples/app/examples/card/focus.tsx
@@ -1,6 +1,7 @@
 import "@postenbring/hedwig-css";
 import { Card, Container, Link } from "@postenbring/hedwig-react";
 import postenBringImage from "../../assets/posten-bring.avif";
+import vectoriImage from "../../assets/customer-parcel.svg";
 
 function Example() {
   return (
@@ -15,8 +16,9 @@ function Example() {
         <Card variant="focus">
           <Card.Media>
             <Card.MediaImg
-              alt="Posten delivery van with Bring cargo truck in the background"
+              alt="Use variant=crop on photographs, to make the image fill the frame completely"
               src={postenBringImage}
+              variant="crop"
             />
           </Card.Media>
           <Card.Body>
@@ -42,8 +44,9 @@ function Example() {
         <Card variant="focus" color="dark" imagePosition="right">
           <Card.Media>
             <Card.MediaImg
-              alt="Posten delivery van with Bring cargo truck in the background"
+              alt="Use variant=crop on photographs, to make the image fill the frame completely"
               src={postenBringImage}
+              variant="crop"
             />
           </Card.Media>
           <Card.Body>
@@ -60,6 +63,33 @@ function Example() {
               <Link href="posten.no" variant="inverted">
                 <Card.BodyActionArrow direction="up-right" />
                 External link
+              </Link>
+            </Card.BodyAction>
+          </Card.Body>
+        </Card>
+
+        <h2>Scale illustrations (no cropping)</h2>
+        <Card variant="focus" color="dark">
+          <Card.Media>
+            <Card.MediaImg
+              alt="Images with transparent backgrounds (eg. SVG's, some PNG's) should be used with variant=scale, or no variant prop at all. This leaves some empty space on the sides/above/below if needed for showing the full image."
+              src={vectoriImage}
+            />
+          </Card.Media>
+          <Card.Body>
+            <Card.BodyHeader as="h2">
+              <Card.BodyHeaderOverline>Overline title</Card.BodyHeaderOverline>
+              <Card.BodyHeaderTitle>Import duties</Card.BodyHeaderTitle>
+            </Card.BodyHeader>
+            <Card.BodyDescription>
+              Images with transparent backgrounds (eg. SVG&lsquo;s, some PNG&lsquo;s) should be used
+              with variant=scale, or no variant prop at all. This leaves some empty space on the
+              sides/above/below if needed for showing the full image.
+            </Card.BodyDescription>
+            <Card.BodyAction asChild>
+              <Link href="https://www.posten.no" variant="inverted" icon="leading">
+                <Card.BodyActionArrow direction="right" />
+                Internal link
               </Link>
             </Card.BodyAction>
           </Card.Body>

--- a/apps/examples/app/examples/card/full-width.tsx
+++ b/apps/examples/app/examples/card/full-width.tsx
@@ -1,6 +1,7 @@
 import "@postenbring/hedwig-css";
 import { Card, Link, Container, Button, ButtonList } from "@postenbring/hedwig-react";
 import postenBringImage from "../../assets/posten-bring.avif";
+import vectoriImage from "../../assets/customer-parcel.svg";
 
 function Example() {
   return (
@@ -15,8 +16,9 @@ function Example() {
         <Card variant="full-width" color="lighter-brand">
           <Card.Media>
             <Card.MediaImg
-              alt="Posten delivery van with Bring cargo truck in the background"
+              alt="Use variant=crop on photographs, to make the image fill the frame completely"
               src={postenBringImage}
+              variant="crop"
             />
           </Card.Media>
           <Card.Body>
@@ -38,12 +40,14 @@ function Example() {
             </Card.BodyAction>
           </Card.Body>
         </Card>
+
         <h2>Color - Lighter Brand - Default - Image right</h2>
         <Card variant="full-width" color="lighter-brand" imagePosition="right">
           <Card.Media>
             <Card.MediaImg
-              alt="Posten delivery van with Bring cargo truck in the background"
+              alt="Use variant=crop on photographs, to make the image fill the frame completely"
               src={postenBringImage}
+              variant="crop"
             />
           </Card.Media>
           <Card.Body>
@@ -69,8 +73,9 @@ function Example() {
         <Card variant="full-width" color="light-grey-fill">
           <Card.Media>
             <Card.MediaImg
-              alt="Posten delivery van with Bring cargo truck in the background"
+              alt="Use variant=crop on photographs, to make the image fill the frame completely"
               src={postenBringImage}
+              variant="crop"
             />
           </Card.Media>
           <Card.Body>
@@ -92,12 +97,14 @@ function Example() {
             </Card.BodyAction>
           </Card.Body>
         </Card>
+
         <h2>Color - White</h2>
         <Card variant="full-width" color="white">
           <Card.Media>
             <Card.MediaImg
-              alt="Posten delivery van with Bring cargo truck in the background"
+              alt="Use variant=crop on photographs, to make the image fill the frame completely"
               src={postenBringImage}
+              variant="crop"
             />
           </Card.Media>
           <Card.Body>
@@ -123,8 +130,9 @@ function Example() {
         <Card variant="full-width" color="lighter-brand">
           <Card.Media>
             <Card.MediaImg
-              alt="Posten delivery van with Bring cargo truck in the background"
+              alt="Use variant=crop on photographs, to make the image fill the frame completely"
               src={postenBringImage}
+              variant="crop"
             />
           </Card.Media>
           <Card.Body>
@@ -146,12 +154,14 @@ function Example() {
             </Card.BodyActionRow>
           </Card.Body>
         </Card>
+
         <h2>More CTA Buttons</h2>
         <Card variant="full-width" color="lighter-brand">
           <Card.Media>
             <Card.MediaImg
-              alt="Posten delivery van with Bring cargo truck in the background"
+              alt="Use variant=crop on photographs, to make the image fill the frame completely"
               src={postenBringImage}
+              variant="crop"
             />
           </Card.Media>
           <Card.Body>
@@ -192,13 +202,13 @@ function Example() {
             </Card.BodyActionRow>
           </Card.Body>
         </Card>
-        <h2>Scale image, no cropping</h2>
+
+        <h2>Scale illustration (no cropping)</h2>
         <Card variant="full-width" color="lighter-brand">
           <Card.Media>
             <Card.MediaImg
-              alt="Posten delivery van with Bring cargo truck in the background"
-              variant="scale"
-              src={postenBringImage}
+              alt="Images with transparent backgrounds (eg. SVG's, some PNG's) should be used with variant=crop, or no variant prop at all"
+              src={vectoriImage}
             />
           </Card.Media>
           <Card.Body>
@@ -219,7 +229,8 @@ function Example() {
               >
                 variant=&quot;scale&quot;
               </pre>{" "}
-              on the image disables the cropping behavior when images resize.
+              on the image disables the cropping behavior when images resize. This prop&lsquo;s
+              default is &quot;scale&quot; already, so the variant prop can just be skipped.
             </Card.BodyDescription>
             <Card.BodyActionRow>
               <Card.BodyAction asChild>

--- a/packages/css/src/card/card.css
+++ b/packages/css/src/card/card.css
@@ -28,10 +28,10 @@
   .hds-card__media__img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
 
-    &.hds-card__img__scale {
-      object-fit: contain;
+    &.hds-card__img__crop {
+      object-fit: cover;
     }
   }
 

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -29,7 +29,7 @@ export interface CardImageMediaProps extends React.ImgHTMLAttributes<HTMLImageEl
    * "scale": No cropping, image scales to the maximum size available and centers.
    *          If the aspect ratio doesn't match, then the background will show on the top/bottom or left/right sides of the image.
    *
-   * @default "crop"
+   * @default "scale"
    */
   variant?: "crop" | "scale";
 }
@@ -41,7 +41,7 @@ export const CardMediaImg = forwardRef<HTMLImageElement, CardImageMediaProps>(
         {...rest}
         className={clsx(
           "hds-card__media__img",
-          { "hds-card__img__scale": variant === "scale" },
+          { "hds-card__img__crop": variant === "crop" },
           className as undefined,
         )}
         ref={ref}


### PR DESCRIPTION
Switch the default variant for scaling Card.MediaImg, from 'crop' to 'scale'.