### PR TITLE
Adjust fullwidth card buttons

### DIFF
--- a/.changeset/tender-mammals-smoke.md
+++ b/.changeset/tender-mammals-smoke.md
@@ -1,0 +1,6 @@
+---
+"@postenbring/hedwig-react": patch
+"@postenbring/hedwig-css": patch
+---
+
+Add buttons to focus card example

--- a/.changeset/tender-mammals-smoke.md
+++ b/.changeset/tender-mammals-smoke.md
@@ -3,4 +3,4 @@
 "@postenbring/hedwig-css": patch
 ---
 
-Add buttons to focus card example
+Make buttons fill available width on fullwidth (and focus/hero) cards when there are multiple buttons. Add buttons to focus card example.

--- a/apps/examples-v3/app/examples/card/focus.tsx
+++ b/apps/examples-v3/app/examples/card/focus.tsx
@@ -1,5 +1,5 @@
 import "@postenbring/hedwig-css";
-import { Card, Container, Link } from "@postenbring/hedwig-react";
+import { Card, Container, Link, ButtonList, Button } from "@postenbring/hedwig-react";
 import postenBringImage from "../../assets/posten-bring.avif";
 
 function Example() {
@@ -62,6 +62,45 @@ function Example() {
                 External link
               </Link>
             </Card.BodyAction>
+          </Card.Body>
+        </Card>
+
+        <h2>Buttons</h2>
+        <Card variant="focus">
+          <Card.Media>
+            <Card.MediaImg
+              alt="Use variant=crop on photographs, to make the image fill the frame completely"
+              src={postenBringImage}
+              variant="crop"
+            />
+          </Card.Media>
+          <Card.Body>
+            <Card.BodyHeader as="h2">
+              <Card.BodyHeaderOverline>Overline title</Card.BodyHeaderOverline>
+              <Card.BodyHeaderTitle>Import duties</Card.BodyHeaderTitle>
+            </Card.BodyHeader>
+            <Card.BodyDescription>
+              For more than 1 CTA button, use &lt;ButtonList variant=&quot;stretched&quot;, and add
+              an &lsquo;asChild&lsquo; prop to the surrounding Card.BodyActionRow.
+            </Card.BodyDescription>
+            <Card.BodyActionRow asChild>
+              <ButtonList variant="stretched">
+                <Card.BodyAction asChild>
+                  <Button fullWidth="mobile" asChild>
+                    <a href="https://www.postenbring.no" target="_blank" rel="noreferrer">
+                      Primary
+                    </a>
+                  </Button>
+                </Card.BodyAction>
+                <Card.BodyAction asChild>
+                  <Button fullWidth="mobile" variant="secondary" asChild>
+                    <a href="https://www.posten.no" target="_blank" rel="noreferrer">
+                      Secondary
+                    </a>
+                  </Button>
+                </Card.BodyAction>
+              </ButtonList>
+            </Card.BodyActionRow>
           </Card.Body>
         </Card>
       </div>

--- a/apps/examples-v3/app/examples/card/focus.tsx
+++ b/apps/examples-v3/app/examples/card/focus.tsx
@@ -93,9 +93,9 @@ function Example() {
                   </Button>
                 </Card.BodyAction>
                 <Card.BodyAction asChild>
-                  <Button fullWidth="mobile" variant="secondary" asChild>
+                  <Button fullWidth="mobile" variant="inverted" asChild>
                     <a href="https://www.posten.no" target="_blank" rel="noreferrer">
-                      Secondary
+                      Inverted
                     </a>
                   </Button>
                 </Card.BodyAction>

--- a/packages/css/src/card/fullwidth-focus.css
+++ b/packages/css/src/card/fullwidth-focus.css
@@ -79,6 +79,7 @@
 
       .hds-card__body-action {
         margin-top: 0;
+        width: inherit;
       }
     }
 
@@ -101,6 +102,10 @@
         .hds-card__media {
           max-height: var(--hds-fullwidthcard-image-maxheight-medium);
         }
+      }
+
+      .hds-card__centerbody {
+        width: 100%;
       }
 
       /* Image is absolutely positioned within .hds-card__media, to center and avoid making .hds-card__media outgrow


### PR DESCRIPTION
Multiple buttons should fill available width
Inverted secondary buttons in focus-card example