### PR TITLE
Fullwidthcard wide image

### DIFF
--- a/.changeset/seven-cases-glow.md
+++ b/.changeset/seven-cases-glow.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-css": patch
+---
+
+Remove styling that sets square and portrait format on fullwidthcard-images on narrow screens

--- a/packages/css/src/card/card.css
+++ b/packages/css/src/card/card.css
@@ -37,6 +37,7 @@
 
     &.hds-card__img__crop {
       object-fit: cover;
+      position: absolute;
     }
   }
 

--- a/packages/css/src/card/fullwidth-focus.css
+++ b/packages/css/src/card/fullwidth-focus.css
@@ -29,18 +29,6 @@
       border-radius: var(--hds-border-radius-8);
       max-height: var(--hds-fullwidthcard-image-maxheight-small);
       width: 100%;
-
-      /*  Responsivity: different card layouts and content/images sizes, while still displaying as much as the image as
-			 *  possible and trying to keep focus on the middle, .hds-card__media is displayed in particular ways on
-			 *  particular viewport widths, but always filling the available width (which below 800px is the full width of the
-			 *  card minus padding, and above 800px is only half the width of the card):
-			 *
-			 **/
-
-      /* "Widest" of the narrow card layouts: fixed image height (but higher now) */
-      @container fullwidthcard (width >= 648px) and (width < 800px) {
-        height: var(--hds-fullwidthcard-image-height-medium);
-      }
     }
 
     .hds-card__body {

--- a/packages/css/src/card/fullwidth-focus.css
+++ b/packages/css/src/card/fullwidth-focus.css
@@ -29,6 +29,22 @@
       border-radius: var(--hds-border-radius-8);
       max-height: var(--hds-fullwidthcard-image-maxheight-small);
       width: 100%;
+
+      @container fullwidthcard (width >= 280px) {
+        min-height: 210px;
+
+        img {
+          min-height: 210px;
+        }
+      }
+
+      @container fullwidthcard (width < 280px) {
+        aspect-ratio: 4 / 3;
+
+        img {
+          aspect-ratio: 4 / 3;
+        }
+      }
     }
 
     .hds-card__body {

--- a/packages/css/src/card/fullwidth-focus.css
+++ b/packages/css/src/card/fullwidth-focus.css
@@ -37,17 +37,6 @@
 			 *
 			 **/
 
-      /* Narrowest: fixed aspect ratio (portrait: height is 1.5 times the width). */
-      @container fullwidthcard (width < 300px) {
-        aspect-ratio: var(--hds-fullwidthcard-image-aspect-mini);
-        max-height: var(--hds-fullwidthcard-image-height-small);
-      }
-
-      /* Middle narrow: fixed aspect ratio (quare format), variable height */
-      @container fullwidthcard (width >= 300px) and (width < 648px) {
-        aspect-ratio: 1;
-      }
-
       /* "Widest" of the narrow card layouts: fixed image height (but higher now) */
       @container fullwidthcard (width >= 648px) and (width < 800px) {
         height: var(--hds-fullwidthcard-image-height-medium);

--- a/packages/css/src/card/fullwidth-focus.css
+++ b/packages/css/src/card/fullwidth-focus.css
@@ -8,10 +8,10 @@
     --hds-fullwidthcard-content-min-height: calc(
       var(--hds-fullwidthcard-min-height) - 2 * var(--hds-spacing-20-24)
     );
-    --hds-fullwidthcard-image-aspect-mini: 100 / 155;
+    --hds-fullwidthcard-image-aspect-mini: 4 / 3;
     --hds-fullwidthcard-image-maxheight-small: 420px;
     --hds-fullwidthcard-image-maxheight-medium: 650px;
-    --hds-fullwidthcard-image-height-small: 300px;
+    --hds-fullwidthcard-image-height-small: 330px;
     --hds-fullwidthcard-image-height-medium: 600px;
 
     max-width: inherit;
@@ -30,19 +30,19 @@
       max-height: var(--hds-fullwidthcard-image-maxheight-small);
       width: 100%;
 
-      @container fullwidthcard (width >= 280px) {
-        min-height: 210px;
+      @container fullwidthcard (width >= 440px) {
+        min-height: var(--hds-fullwidthcard-image-height-small);
 
         img {
-          min-height: 210px;
+          min-height: var(--hds-fullwidthcard-image-height-small);
         }
       }
 
-      @container fullwidthcard (width < 280px) {
-        aspect-ratio: 4 / 3;
+      @container fullwidthcard (width < 440px) {
+        aspect-ratio: var(--hds-fullwidthcard-image-aspect-mini);
 
         img {
-          aspect-ratio: 4 / 3;
+          aspect-ratio: var(--hds-fullwidthcard-image-aspect-mini);
         }
       }
     }


### PR DESCRIPTION
Makes image-adapted `object-position` props (with info from eg. Enonic XP's focus point) handle responsivity. Assumes source images are 16:9 format, which is optimal for the way images behave in fullwidth cards.