### PR TITLE
Add special-case padding at the bottom of the navbar menu

### DIFF
--- a/packages/css/src/navbar/navbar.css
+++ b/packages/css/src/navbar/navbar.css
@@ -67,6 +67,7 @@
         opacity: 1;
         transition-delay: var(--_animation-time);
         overflow-y: auto;
+        padding-bottom: 90px;
       }
     }
 


### PR DESCRIPTION
Hard to replicate, but it appears some browsers (screenshot is from safari on iphone 16) have overlaying gui elements that make the bottom of the navbar unreachable, so the bottom links can't be clicked. This fix adds bottom padding to enforce some room to scroll down.
<img width="400" alt="image" src="https://github.com/user-attachments/assets/7535bf23-4f9a-4323-bd5d-35208fe928bc" />
