### PR TITLE
Deprecate some colors that were missed

### DIFF
--- a/.changeset/bright-lamps-sin.md
+++ b/.changeset/bright-lamps-sin.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-tokens": patch
+---
+
+Deprecate some colors that were missed

--- a/packages/tokens/tailwind.config.cjs
+++ b/packages/tokens/tailwind.config.cjs
@@ -32,12 +32,12 @@ function expandAndPrefix(obj, prefix) {
 }
 
 /**
- * 
- * @param {Record<string, unknown>} obj 
- * @param {string} key 
+ *
+ * @param {Record<string, unknown>} obj
+ * @param {string} key
  */
 function omitKey(obj, key) {
-  const {[key]: _, ...rest} = obj;
+  const { [key]: _, ...rest } = obj;
   return rest;
 }
 
@@ -125,16 +125,25 @@ module.exports = {
     },
     colors: {
       // The brand specifc tokens are themeable,
-      // so they must be referneced by css variables
+      // so they must be referenced by css variables
+      // @deprecated Use the new color scheme instead
       signature: "var(--hds-colors-signature)",
+      // @deprecated Use the new color scheme instead
       darker: "var(--hds-colors-darker)",
+      // @deprecated Use the new color scheme instead
       dark: "var(--hds-colors-dark)",
+      // @deprecated Use the new color scheme instead
       light: "var(--hds-colors-light)",
+      // @deprecated Use the new color scheme instead
       lighter: "var(--hds-colors-lighter)",
+      // @deprecated Use the new color scheme instead
       "signature-hover": "var(--hds-colors-signature-hover)",
+      // @deprecated Use the new color scheme instead
       "light-hover": "var(--hds-colors-light-hover)",
 
+      // @deprecated Use the new color scheme instead
       ...expandAndPrefix(tokens["ui-colors"], "ui-"),
+      // @deprecated Use the new color scheme instead
       ...expandAndPrefix(tokens["dark-mode-colors"], "dm-"),
     },
     spacing: {

--- a/packages/tokens/tokens-source/brands/bring.json
+++ b/packages/tokens/tokens-source/brands/bring.json
@@ -3,6 +3,8 @@
     "$type": "color",
     "signature": {
       "$value": "{bring-colors.signature-green}",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "darker": {
@@ -19,18 +21,26 @@
     },
     "light": {
       "$value": "{bring-colors.light-green}",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "lighter": {
       "$value": "{bring-colors.lighter-green}",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "signature-hover": {
       "$value": "{bring-colors.signature-green-hover}",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "light-hover": {
       "$value": "{bring-colors.light-green-hover}",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "_deprecated": true

--- a/packages/tokens/tokens-source/brands/posten.json
+++ b/packages/tokens/tokens-source/brands/posten.json
@@ -3,30 +3,44 @@
     "$type": "color",
     "signature": {
       "$value": "{posten-colors.signature-red}",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "darker": {
       "$value": "{posten-colors.darker-red}",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "dark": {
       "$value": "{posten-colors.dark-red}",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "light": {
       "$value": "{posten-colors.light-red}",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "lighter": {
       "$value": "{posten-colors.lighter-red}",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "signature-hover": {
       "$value": "{posten-colors.signature-red-hover}",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "light-hover": {
       "$value": "{posten-colors.light-red-hover}",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "_deprecated": true

--- a/packages/tokens/tokens-source/shared.json
+++ b/packages/tokens/tokens-source/shared.json
@@ -9,26 +9,38 @@
     },
     "darker-red": {
       "$value": "#4a1011",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "dark-red": {
       "$value": "#980000",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "light-red": {
       "$value": "#ffb5af",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "lighter-red": {
       "$value": "#fff5f0",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "signature-red-hover": {
       "$value": "#ca201c",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "light-red-hover": {
       "$value": "#ffa199",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "_deprecated": true
@@ -37,30 +49,44 @@
     "$type": "color",
     "signature-green": {
       "$value": "#56b529",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "darker-green": {
       "$value": "#002f19",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "dark-green": {
       "$value": "#00643a",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "light-green": {
       "$value": "#b5e099",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "lighter-green": {
       "$value": "#f1f7e9",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "signature-green-hover": {
       "$value": "#6ec943",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "light-green-hover": {
       "$value": "#d3e593",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "_deprecated": true
@@ -69,46 +95,68 @@
     "$type": "color",
     "black": {
       "$value": "#000000",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "dark-grey": {
       "$value": "#6e6e6e",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "grey": {
       "$value": "#d6d6d6",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "light-grey-stroke": {
       "$value": "#e4e4e4",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "light-grey-fill": {
       "$value": "#f2f2f2",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "white": {
       "$value": "#ffffff",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "warning-yellow": {
       "$value": "#fdbb2f",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "warning-yellow-stroke": {
       "$value": "#d68000",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "warning-yellow-light-fill": {
       "$value": "#fff5e0",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "warning-yellow-hover": {
       "$value": "#ffc340",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "black-hover": {
       "$value": "#1e1e1e",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead"
     },
     "_deprecated": true
@@ -117,22 +165,32 @@
     "$type": "color",
     "obsidian": {
       "$value": "#121212",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead - Base color for dark mode"
     },
     "coal": {
       "$value": "#252525",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead - Background on none-clickable cards"
     },
     "dusk": {
       "$value": "#2c2c2c",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead - Fill inputfields, checkbox, radio buttons, toogles"
     },
     "spider": {
       "$value": "#333333",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead - Clickable cards or tiles"
     },
     "ash": {
       "$value": "#999999",
+      "deprecated": true,
+      "deprecated_comment": "Use the new color scheme instead",
       "description": "@deprecated Use the new color scheme instead - Default radio buttons, checkbox, label on inputsfields, toogle off  (background)"
     },
     "_deprecated": true


### PR DESCRIPTION
Deprecate some color tokens in tailwind.config.cjs
Properly deprecate the deprecated color tokens in bring, posten and shared