### PR TITLE
Fix Error summary link texts in light mode

### DIFF
--- a/.changeset/pretty-eggs-learn.md
+++ b/.changeset/pretty-eggs-learn.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-react": patch
+---
+
+Fix Error summary link texts in light mode

--- a/packages/css/src/form/error-summary/error-summary.css
+++ b/packages/css/src/form/error-summary/error-summary.css
@@ -1,6 +1,4 @@
 .hds-error-summary {
-  color: var(--hds-colors-error-base-contrast-default);
-  background-color: var(--hds-colors-error-base-default);
   display: flex;
   flex-direction: column;
   gap: var(--hds-spacing-12);

--- a/packages/react/src/form/error-summary/error-summary.tsx
+++ b/packages/react/src/form/error-summary/error-summary.tsx
@@ -129,7 +129,12 @@ export type ErrorSummaryProps = Omit<
 
 export const ErrorSummary = forwardRef<HTMLDivElement, ErrorSummaryProps>(
   ({ children, className, ...rest }, ref) => (
-    <Box ref={ref} {...rest} className={clsx(`hds-error-summary`, className as undefined)}>
+    <Box
+      data-color-scheme="dark"
+      ref={ref}
+      {...rest}
+      className={clsx(`hds-error-summary`, className as undefined)}
+    >
       {children}
     </Box>
   ),

--- a/packages/react/src/form/error-summary/error-summary.tsx
+++ b/packages/react/src/form/error-summary/error-summary.tsx
@@ -130,7 +130,7 @@ export type ErrorSummaryProps = Omit<
 export const ErrorSummary = forwardRef<HTMLDivElement, ErrorSummaryProps>(
   ({ children, className, ...rest }, ref) => (
     <Box
-      data-color-scheme="dark"
+      data-color="error"
       ref={ref}
       {...rest}
       className={clsx(`hds-error-summary`, className as undefined)}


### PR DESCRIPTION
Always set `data-color-scheme="dark"` for Error summary