### PR TITLE
Buxfix: ButtonList stretched with icons

### DIFF
--- a/.changeset/social-memes-brake.md
+++ b/.changeset/social-memes-brake.md
@@ -1,0 +1,5 @@
+---
+"@postenbring/hedwig-css": patch
+---
+
+Visual bugfix for buttons with icons in buttonlist variant stretched

--- a/apps/examples/app/examples/button-list/stretched-with-icons.tsx
+++ b/apps/examples/app/examples/button-list/stretched-with-icons.tsx
@@ -1,0 +1,27 @@
+import "@postenbring/hedwig-css";
+import { Button, ButtonList } from "@postenbring/hedwig-react";
+import { GlobeIcon, EnvelopeIcon } from "../../assets/icon-examples";
+
+function Example() {
+  return (
+    <ButtonList variant="stretched">
+      <Button icon="trailing">
+        First button <GlobeIcon />
+      </Button>
+      <Button variant="secondary" icon="trailing">
+        Second button <GlobeIcon />
+      </Button>
+      <Button variant="tertiary" icon="leading">
+        <EnvelopeIcon /> Third button
+      </Button>
+    </ButtonList>
+  );
+}
+
+export default Example;
+
+import type { ExampleConfig } from "..";
+export const config: ExampleConfig = {
+  index: 1,
+  layout: "centered-fullwidth",
+};

--- a/apps/examples/app/examples/button-list/stretched-with-icons.tsx
+++ b/apps/examples/app/examples/button-list/stretched-with-icons.tsx
@@ -22,6 +22,6 @@ export default Example;
 
 import type { ExampleConfig } from "..";
 export const config: ExampleConfig = {
-  index: 1,
+  index: 2,
   layout: "centered-fullwidth",
 };

--- a/packages/css/src/button-list/button-list.css
+++ b/packages/css/src/button-list/button-list.css
@@ -14,7 +14,7 @@
     justify-content: space-between;
     flex-direction: column;
 
-    & * {
+    & *:not(svg, path) {
       flex-grow: 1;
       justify-content: center;
       flex-basis: 0;


### PR DESCRIPTION
Buttons with icons in a ButtonList with variant stretched did not center the text and icon. Exclude svg and path from css selector that sets flex properties.

Before:
<img width="1359" height="81" alt="Screenshot 2026-05-27 at 10 29 56" src="https://github.com/user-attachments/assets/39598569-e808-41a9-97da-6db7667da28d" />

After:
<img width="1305" height="81" alt="Screenshot 2026-05-27 at 10 29 40" src="https://github.com/user-attachments/assets/050071c2-ad80-4579-a98e-2368d3cedfeb" />
