### PR TITLE
fix: prevent close button overlapping long text

### DIFF
--- a/packages/css/src/help-text/help-text.css
+++ b/packages/css/src/help-text/help-text.css
@@ -44,6 +44,7 @@
 .hds-help-text-box {
   min-width: var(--hds-spacing-160);
   max-width: min(100vw, 400px);
+  padding-inline-end: var(--hds-spacing-48);
 
   /* Animation */
   animation-duration: var(--hds-micro-animation-duration-normal);


### PR DESCRIPTION
Problem: 
The close button overlaps the help text when the text is long, which does not look good. 

Fix:
Add spacing between text and close button 

Is this a fair solution? All feedback is gladly welcome? 

Before: 
<img width="1737" height="888" alt="image" src="https://github.com/user-attachments/assets/0c79cba1-accb-4d35-971d-79730f8f6af9" />


After: 
<img width="1756" height="908" alt="image" src="https://github.com/user-attachments/assets/69b8383c-113d-494c-8cc0-7e7175cef4aa" />
